### PR TITLE
docs: Add ADR-018 for transcription evaluation metrics

### DIFF
--- a/documentation/adr/018-transcription-evaluation-metrics.md
+++ b/documentation/adr/018-transcription-evaluation-metrics.md
@@ -1,0 +1,143 @@
+# ADR-018: Transcription Evaluation Metrics
+
+## Status
+
+Proposed
+
+Date of decision: 2026-02-16
+
+## Context and Problem Statement
+
+When evaluating speech-to-text systems against reference transcripts (golden or synthetic), we need appropriate metrics to quantify transcription quality. Different metrics capture different aspects of transcription accuracy, from word-level errors to semantic equivalence and speaker attribution. Which metrics should we use to comprehensively evaluate transcription system performance while providing actionable insights?
+
+## Considered Options
+
+* Word Error Rate (WER)
+* Character Error Rate (CER)
+* Jaccard Word Error Rate
+* Speaker-attributed Word Error Rate (SA-WER)
+* Diarization Error Rate (DER)
+* Word Diarization Error Rate (WDER) / Speaker Confusion Rate
+* Speaker Count Deviation and Accuracy
+* Bidirectional Entailment
+* Hedging, Modality, and Register Shift Detection
+* Named Entity Recognition (NER) Comparison
+
+## Decision Outcome
+
+WER, WDER, Speaker Count Deviation and Accuracy, Jaccard Word Error Rate, and Bidirectional Entailment, because they provide comprehensive coverage of transcription quality from word-level accuracy (WER), speaker attribution (WDER), basic diarization validation (Speaker Count), vocabulary coverage (Jaccard), and semantic preservation (Bidirectional Entailment).
+
+## Pros and Cons of the Options
+
+### Word Error Rate (WER)
+
+*What percentage of words need to be changed to get the perfect transcript (without considering speakers)?*
+
+WER measures the minimum number of word-level edits (insertions, deletions, substitutions) required to transform the hypothesis transcript into the reference transcript, normalized by the reference length.
+
+* Good, because it is easy to compute using standard libraries.
+* Good, because it is easy to understand and widely adopted in the field.
+* Bad, because it doesn't capture speaker-level information.
+* Bad, because it is agnostic to word importance, allowing critical errors to be overshadowed by trivial ones.
+
+### Character Error Rate (CER)
+
+*What percentage of characters need to be changed to get the perfect transcript (without considering speakers)?*
+
+CER measures character-level edits required to transform the hypothesis into the reference, similar to WER but at character granularity.
+
+* Good, because it captures finer-grained errors than WER.
+* Bad, because pronunciational inconsistencies in English can spike CER and make it noisy.
+* Bad, because it captures similar information to WER but is less interpretable.
+
+### Jaccard Word Error Rate
+
+*What proportion of the expected vocabulary is present in the transcript?*
+
+An extension of WER that considers vocabulary overlap between reference and hypothesis transcripts, measuring what proportion of the expected vocabulary is present rather than exact word-by-word accuracy.
+
+* Good, because it doesn't fall into the trap of overshadowing important words with unimportant ones.
+* Good, because it can highlight when key terminology or vocabulary is missing from the transcript.
+* Bad, because it is more difficult to explain than standard WER.
+* Bad, because it doesn't capture the true number of errors in the text (i.e., how many corrections a scribe would need to make).
+
+### Speaker-attributed Word Error Rate (SA-WER)
+
+*What percentage of words need to be changed to get the perfect transcript (considering speakers)?*
+
+A combined metric that attempts to capture both transcription and diarization quality by computing WER while accounting for speaker attribution.
+
+* Good, because it produces a single headline number for overall system quality.
+* Bad, because it is a jack of all trades, master of none—attempting to capture both transcription and diarization quality simultaneously.
+* Bad, because it doesn't allow separate analysis of transcription vs. diarization performance.
+* Bad, because it can be replaced by WER in conjunction with WDER.
+
+### Diarization Error Rate (DER)
+
+*What proportion of audio time is attributed to the wrong speaker?*
+
+A metric designed for standalone diarization systems, measuring the fraction of time that is incorrectly attributed to speakers.
+
+* Good, because it is well-established for evaluating diarization in isolation.
+* Bad, because it is less informative for end-to-end transcription with diarization quality.
+* Bad, because it is normalized in terms of time, which is inconsistent with most other metrics presented.
+* Bad, because it requires more computational work to compute compared to basic metrics (medium CPU).
+
+### Word Diarization Error Rate (WDER) / Speaker Confusion Rate
+
+*What is the percentage of the words that were transcribed correctly, but were attributed to the wrong speaker?*
+
+Also known as Speaker Confusion Rate, WDER measures speaker attribution errors at the word level.
+
+* Good, because it is modular and can be summed with WER to recover SA-WER (WER + WDER = SA-WER).
+* Good, because it isolates diarization quality from transcription quality for separate diagnosis.
+* Good, because it is built for end-to-end transcription with diarization systems.
+* Bad, because it is not a commonly used metric, requiring careful implementation.
+* Bad, because it is not covered by any downstream libraries as far as can be determined.
+* Bad, because it requires more computational work to compute compared to basic metrics (medium CPU).
+
+### Speaker Count Deviation and Accuracy
+
+*Did the system recognize the right number of speakers?*
+
+A simple metric counting how many times the detected number of speakers corresponds correctly to the number of speakers present in the reference.
+
+* Good, because it is a simple metric to explain.
+* Good, because it identifies a clear mode of failure where incorrect speaker count is always counted as an error.
+* Bad, because it doesn't capture other important transcription information.
+* Bad, because it can significantly tarnish the perception of an otherwise good transcription (binary pass/fail regardless of deviation magnitude).
+
+### Bidirectional Entailment
+
+*Was the meaning completely preserved, and were extra meanings introduced in the transcription process?*
+
+Uses NLI models to check bidirectional entailment between reference and hypothesis, verifying that all information in each is present in the other, effectively testing semantic equivalence.
+
+* Good, because it can capture non-trivial situations where AI makes mistakes that have high impact on the actual transcript.
+* Good, because it can detect contradictions, as contradicting statements will convey contradicting information.
+* Bad, because if we identify issues, there is very little we can do about the system, especially if other metrics indicate this is the best available option.
+* Bad, because it requires significant computational power (e.g., basic AI-capable GPU).
+
+### Hedging, Modality, and Register Shift Detection
+
+*Has the meaning shifted slightly in linguistic terms?*
+
+Detects shifts in linguistic features such as hedging (certainty level), modality (must vs. should), and register (formality level) between reference and hypothesis.
+
+* Good, because it provides an easy way to pinpoint specific types of mistakes.
+* Good, because it can capture important quirks where non-crucial but important language features shift (e.g., "must" becoming "should").
+* Good, because these shifts can have significant impact on meaning while preserving much of the original semantic content.
+* Bad, because addressing these problems is unclear when other metrics show the system is optimal.
+* Bad, because it requires significant computational power (e.g., basic AI-capable GPU).
+
+### Named Entity Recognition (NER) Comparison
+
+*Have named entities such as people, organizations, and places been mistranscribed?*
+
+Compares the sets of named entities detected in reference and hypothesis transcripts to identify entity-level errors.
+
+* Good, because it can specifically target errors like mistranscription of names or concepts.
+* Good, because it can quickly spot mistakes by comparing entities present in reference but not in hypothesis, and vice versa.
+* Bad, because addressing these problems is unclear when other metrics show the system is optimal.
+* Bad, because it requires significant computational power (e.g., basic AI-capable GPU).
+

--- a/documentation/adr/018-transcription-evaluation-metrics.md
+++ b/documentation/adr/018-transcription-evaluation-metrics.md
@@ -68,7 +68,7 @@ An extension of WER that considers vocabulary overlap between reference and hypo
 A combined metric that attempts to capture both transcription and diarization quality by computing WER while accounting for speaker attribution.
 
 * Good, because it produces a single headline number for overall system quality.
-* Bad, because it is a jack of all trades, master of none—attempting to capture both transcription and diarization quality simultaneously.
+* Bad, because it is attempting to capture both transcription and diarization quality simultaneously.
 * Bad, because it doesn't allow separate analysis of transcription vs. diarization performance.
 * Bad, because it can be replaced by WER in conjunction with WDER.
 
@@ -115,6 +115,7 @@ Uses NLI models to check bidirectional entailment between reference and hypothes
 
 * Good, because it can capture non-trivial situations where AI makes mistakes that have high impact on the actual transcript.
 * Good, because it can detect contradictions, as contradicting statements will convey contradicting information.
+* Good, because it can define a clear failure mode.
 * Bad, because if we identify issues, there is very little we can do about the system, especially if other metrics indicate this is the best available option.
 * Bad, because it requires significant computational power (e.g., basic AI-capable GPU).
 

--- a/documentation/adr/018-transcription-evaluation-metrics.md
+++ b/documentation/adr/018-transcription-evaluation-metrics.md
@@ -25,7 +25,7 @@ When evaluating speech-to-text systems against reference transcripts (golden or 
 
 ## Decision Outcome
 
-WER, WDER, Speaker Count Deviation and Accuracy, Jaccard Word Error Rate, and Bidirectional Entailment, because they provide comprehensive coverage of transcription quality from word-level accuracy (WER), speaker attribution (WDER), basic diarization validation (Speaker Count), vocabulary coverage (Jaccard), and semantic preservation (Bidirectional Entailment).
+WER, WDER, and Speaker Count Accuracy, because they provide focused, non-noisy coverage of transcription quality from word-level accuracy (WER), speaker attribution (WDER), and basic diarization validation (Speaker Count) while remaining simple to compute and interpret for comparing providers.
 
 ## Pros and Cons of the Options
 
@@ -118,6 +118,7 @@ Uses NLI models to check bidirectional entailment between reference and hypothes
 * Good, because it can define a clear failure mode.
 * Bad, because if we identify issues, there is very little we can do about the system, especially if other metrics indicate this is the best available option.
 * Bad, because it requires significant computational power (e.g., basic AI-capable GPU).
+* Bad, because it makes comparing providers difficult due to the complexity and variability of NLI model outputs.
 
 ### Hedging, Modality, and Register Shift Detection
 
@@ -130,6 +131,7 @@ Detects shifts in linguistic features such as hedging (certainty level), modalit
 * Good, because these shifts can have significant impact on meaning while preserving much of the original semantic content.
 * Bad, because addressing these problems is unclear when other metrics show the system is optimal.
 * Bad, because it requires significant computational power (e.g., basic AI-capable GPU).
+* Bad, because it makes comparing providers difficult due to the complexity and variability of linguistic analysis outputs.
 
 ### Named Entity Recognition (NER) Comparison
 
@@ -141,4 +143,5 @@ Compares the sets of named entities detected in reference and hypothesis transcr
 * Good, because it can quickly spot mistakes by comparing entities present in reference but not in hypothesis, and vice versa.
 * Bad, because addressing these problems is unclear when other metrics show the system is optimal.
 * Bad, because it requires significant computational power (e.g., basic AI-capable GPU).
+* Bad, because it makes comparing providers difficult due to the complexity and variability of NER model outputs.
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -10498,4 +10498,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.13"
-content-hash = "ccb678343649b7829247f475e49e1664894dc30fc09cbcb36f69e144645b6373"
+content-hash = "5b6191a94ead8097458983f4b91b0738532820386fa3cc3d08811be932c02b2c"


### PR DESCRIPTION
# Overview
Adds ADR-018 documenting the decision on metrics for evaluating speech-to-text systems against reference transcripts. Recommends WER, WDER, Speaker Count, Jaccard, and Bidirectional Entailment for comprehensive coverage of word accuracy, speaker attribution, vocabulary, and semantic preservation.

## JIRA Ticket
https://mhclgdigital.atlassian.net/browse/AIILG-279

## Changes

- Added [documentation/adr/018-transcription-evaluation-metrics.md](cci:7://file:///Users/patkuc/MHCLG/i-ai-minute/documentation/adr/018-transcription-evaluation-metrics.md:0:0-0:0)
- Evaluates 10 metrics with questions, descriptions, and pros/cons
- Decision date: 2026-02-16 (Scheduled ADR review meeting)

## Acceptance Criteria (AC)

- [x] ADR follows repository structure and format
- [x] Each metric includes a clarifying question
- [x] Pros and cons documented for all options
- [x] Decision outcome clearly stated with rationale
- [x] Pre-commit checks pass

---

## Testing (if applicable)

- **Automated**: Pre-commit checks (ruff, ruff-format) pass
- **Manual**: N/A (documentation only)