### PR TITLE
chore: Enable automerge for patch and minor dependency updates

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'communitiesuk/localai-local-transcribe'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
# Overview
Creates a new GitHub action which runs on pull request. This action will automatically approve and merge dependabot prs for patch and minor updates. Crucially it will still require the pipelines to pass, therefore dependency updates which break things won't get merged.

## Changes
- Adds GitHub action to auto-approve and merge patch and minor dependabot PRs.

## Acceptance Criteria (AC)
- [ ] AC1: Action runs with the correct permissions
- [ ] AC2: Updates which fail the checks won't be merged
- [ ] AC3: Minor and patch updates which pass the checks are automatically merged.

---

## Testing (if applicable)
I think we've just got to merge it

## Notes

Followed approach from here https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/automating-dependabot-with-github-actions#enabling-automerge-on-a-pull-request