### PR TITLE
chore: add placeholder ticket link

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 <!-- Required: what + why in 1–3 sentences. -->
 
 ## JIRA Ticket
-<!-- Required: link to the JIRA ticket -->
+https://mhclgdigital.atlassian.net/browse/AIILG-XXX
 
 ## Changes
 <!-- Required: bullet list of key changes. Keep it short. -->


### PR DESCRIPTION
# Overview
Updates our pull request template to add a placeholder ticket link, so you only have to fill in the ticket number.