### PR TITLE
fix: use correct elastic mq urls whether in docker or not

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -18,7 +18,7 @@ REPO=minute
 AUTH_API_URL=http://localhost:8080
 
 USE_ELASTICMQ=true
-ELASTICMQ_URL=http://elasticmq:9324
+ELASTICMQ_URL=http://localhost:9324
 STORAGE_SERVICE_NAME=local
 LOCAL_STORAGE_PATH=./.data
 QUEUE_SERVICE_NAME=sqs

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,7 @@ services:
       - POSTGRES_HOST=db
       - STORAGE_SERVICE_NAME=local
       - LOCAL_STORAGE_PATH=/static
+      - ELASTICMQ_URL=http://elasticmq:9324
 
     depends_on:
       db:


### PR DESCRIPTION
# Overview
Adds an override for the `ELASTICMQ_URL` for when running in docker. Also updates the `.env.local` template to assume you're not running in docker.