### PR TITLE
fix: remove auto staging files changed by the format frontend hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
 
       - id: npm-format
         name: Format frontend files
-        entry: bash -c 'cd frontend && npm exec -- prettier --write "${@#frontend/}" && cd .. && git add "$@"' --
+        entry: bash -c 'cd frontend && npm exec -- prettier --write "${@#frontend/}"' --
         language: system
         pass_filenames: true
         files: ^frontend/.*\.(js|jsx|ts|tsx|json|css|scss|md|yaml|html)$


### PR DESCRIPTION
# Overview
Stops the format frontend files pre-commit hook from auto staging the modified files. This nested git process was causing a locking error.