### PR TITLE
fix: resolve type errors in docker build

### DIFF
--- a/frontend/components/audio/recording-control.tsx
+++ b/frontend/components/audio/recording-control.tsx
@@ -36,7 +36,7 @@ export default function RecordingControl({
   const containerRef = useRef<HTMLDivElement>(null)
   const animationRef = useRef<number | null>(null)
   const analyserRef = useRef<AnalyserNode | null>(null)
-  const dataArrayRef = useRef<Uint8Array | null>(null)
+  const dataArrayRef = useRef<Uint8Array<ArrayBuffer> | null>(null)
   const audioContextRef = useRef<AudioContext | null>(null)
   const [showStopDialog, setShowStopDialog] = useState(false)
   const [localIsPaused, setLocalIsPaused] = useState(false)

--- a/frontend/lib/download-word-doc.ts
+++ b/frontend/lib/download-word-doc.ts
@@ -106,7 +106,7 @@ async function convertHTMLToWordAndDownload(
 ): Promise<void> {
   const processedHtml = preprocessHtml(htmlContent, transcript)
   const result = await asBlob(processedHtml)
-  const blob = result instanceof Blob ? result : new Blob([result])
+  const blob = result instanceof Blob ? result : new Blob([result as BlobPart])
 
   saveAs(blob, fileName)
 }


### PR DESCRIPTION
# Overview
There are some lingering type errors from the upgrade to next.js 16, these are stopping the docker image build from working. This fixes them.