### PR TITLE
feat(ci): Summarisation Evals Pipeline (AIILG-200)

### DIFF
--- a/.github/actions/python-poetry-setup/action.yml
+++ b/.github/actions/python-poetry-setup/action.yml
@@ -1,0 +1,36 @@
+name: Setup Python and Poetry
+description: Common setup for Python and Poetry with caching
+
+inputs:
+  python-version:
+    description: Python version to use
+    required: true
+  poetry-version:
+    description: Poetry version to use
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Set up Poetry
+      uses: abatilo/actions-poetry@v2
+      with:
+        poetry-version: ${{ inputs.poetry-version }}
+
+    - name: Cache virtualenv
+      uses: actions/cache@v4
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+        restore-keys: |
+          venv-${{ runner.os }}-${{ inputs.python-version }}-
+          venv-${{ runner.os }}-
+
+    - name: Configure Poetry to create .venv in project
+      shell: bash
+      run: poetry config virtualenvs.in-project true

--- a/.github/actions/python-poetry-setup/action.yml
+++ b/.github/actions/python-poetry-setup/action.yml
@@ -23,7 +23,7 @@ runs:
         poetry-version: ${{ inputs.poetry-version }}
 
     - name: Cache virtualenv
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: .venv
         key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -24,23 +24,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Setup Python and Poetry
+        uses: ./.github/actions/python-poetry-setup
         with:
           python-version: ${{ inputs.python_version }}
-
-      - name: Set up Poetry
-        uses: abatilo/actions-poetry@v2
-        with:
           poetry-version: ${{ inputs.poetry_version }}
 
       - name: Configure Poetry to create .venv in project
         run: poetry config virtualenvs.in-project true
 
-      - name: Cache virtualenv 
-        uses: actions/cache@v4 
-        with: 
-          path: .venv 
+      - name: Cache virtualenv
+        uses: actions/cache@v4
+        with:
+          path: .venv
           key: venv-${{ runner.os }}-${{ inputs.python_version }}-${{ hashFiles('**/poetry.lock') }}
           restore-keys: |
             venv-${{ runner.os }}-${{ inputs.python_version }}-

--- a/.github/workflows/evals-summarisation-smoke-test.yml
+++ b/.github/workflows/evals-summarisation-smoke-test.yml
@@ -27,6 +27,8 @@ on:
 
 env:
   ENVIRONMENT: test
+  PYTHON_VERSION: "3.12"
+  POETRY_VERSION: "2.3.3"
 
 jobs:
   smoke-test:
@@ -40,8 +42,8 @@ jobs:
       - name: Setup Python and Poetry
         uses: ./.github/actions/python-poetry-setup
         with:
-          python-version: ${{ inputs.python_version }}
-          poetry-version: ${{ inputs.poetry_version }}
+          python-version: ${{ inputs.python_version || env.PYTHON_VERSION }}
+          poetry-version: ${{ inputs.poetry_version || env.POETRY_VERSION }}
 
       - name: Install dependencies
         run: poetry sync --no-root --no-ansi --with evals-summarisation

--- a/.github/workflows/evals-summarisation-smoke-test.yml
+++ b/.github/workflows/evals-summarisation-smoke-test.yml
@@ -46,10 +46,10 @@ jobs:
 
       - name: Run summarisation smoke test
         env:
-          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
-          AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
-          AZURE_DEPLOYMENT: ${{ secrets.AZURE_DEPLOYMENT }}
-          AZURE_API_VERSION: ${{ secrets.AZURE_API_VERSION }}
+          AZURE_APIM_URL: ${{ secrets.AZURE_APIM_URL }}
+          AZURE_APIM_API_VERSION: ${{ secrets.AZURE_APIM_API_VERSION }}
+          AZURE_APIM_ACCESS_TOKEN: ${{ secrets.AZURE_APIM_ACCESS_TOKEN }}
+          AZURE_APIM_SUBSCRIPTION_KEY: ${{ secrets.AZURE_APIM_SUBSCRIPTION_KEY }}
         run: poetry run python -m evals.summarisation.src.main --config evals/summarisation/configs/smoke-test.yaml
 
       - name: Upload smoke test output

--- a/.github/workflows/evals-summarisation-smoke-test.yml
+++ b/.github/workflows/evals-summarisation-smoke-test.yml
@@ -1,0 +1,61 @@
+name: Evals Summarisation Smoke Test
+
+on:
+  workflow_call:
+    inputs: 
+      python_version: 
+        required: true
+        type: string
+      poetry_version: 
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      python_version:
+        description: 'Python version'
+        required: false
+        default: '3.12'
+      poetry_version:
+        description: 'Poetry version'
+        required: false
+        default: '2.3.3'
+
+env:
+  ENVIRONMENT: test
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    environment: release
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Python and Poetry
+        uses: ./.github/actions/python-poetry-setup
+        with:
+          python-version: ${{ inputs.python_version }}
+          poetry-version: ${{ inputs.poetry_version }}
+
+      - name: Install dependencies
+        run: poetry sync --no-root --no-ansi --with evals-summarisation
+
+      - name: Copy env file
+        run: cp .env.example .env
+
+      - name: Run summarisation smoke test
+        env:
+          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          AZURE_DEPLOYMENT: ${{ secrets.AZURE_DEPLOYMENT }}
+          AZURE_API_VERSION: ${{ secrets.AZURE_API_VERSION }}
+        run: poetry run python -m evals.summarisation.src.main --config evals/summarisation/configs/smoke-test.yaml
+
+      - name: Upload smoke test output
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: summarisation-smoke-test-output
+          path: evals/summarisation/output/
+          retention-days: 7

--- a/.github/workflows/evals-summarisation-smoke-test.yml
+++ b/.github/workflows/evals-summarisation-smoke-test.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Setup Python and Poetry
         uses: ./.github/actions/python-poetry-setup
         with:
-          python-version: ${{ inputs.python_version }}
-          poetry-version: ${{ inputs.poetry_version }}
+          python-version: ${{ inputs.python_version || '3.12' }}
+          poetry-version: ${{ inputs.poetry_version || '2.3.3' }}
 
       - name: Install dependencies
         run: poetry sync --no-root --no-ansi --with evals-summarisation

--- a/.github/workflows/evals-summarisation-smoke-test.yml
+++ b/.github/workflows/evals-summarisation-smoke-test.yml
@@ -1,15 +1,16 @@
 name: Summarisation Evals
 
 on:
-  push:
   workflow_call:
     inputs: 
       python_version: 
-        required: true
+        required: false
         type: string
+        default: '3.12'
       poetry_version: 
-        required: true
+        required: false
         type: string
+        default: '2.3.3'
   workflow_dispatch:
     inputs:
       python_version:
@@ -36,8 +37,8 @@ jobs:
       - name: Setup Python and Poetry
         uses: ./.github/actions/python-poetry-setup
         with:
-          python-version: ${{ inputs.python_version || '3.12' }}
-          poetry-version: ${{ inputs.poetry_version || '2.3.3' }}
+          python-version: ${{ inputs.python_version }}
+          poetry-version: ${{ inputs.poetry_version }}
 
       - name: Install dependencies
         run: poetry sync --no-root --no-ansi --with evals-summarisation

--- a/.github/workflows/evals-summarisation-smoke-test.yml
+++ b/.github/workflows/evals-summarisation-smoke-test.yml
@@ -2,10 +2,6 @@ name: Evals Summarisation Smoke Test
 
 on:
   push:
-    branches:
-      - "feature/**"
-    paths:
-      - .github/workflows/evals-summarisation-smoke-test.yml
   workflow_call:
     inputs: 
       python_version: 
@@ -27,8 +23,6 @@ on:
 
 env:
   ENVIRONMENT: test
-  PYTHON_VERSION: "3.12"
-  POETRY_VERSION: "2.3.3"
 
 jobs:
   smoke-test:
@@ -42,8 +36,8 @@ jobs:
       - name: Setup Python and Poetry
         uses: ./.github/actions/python-poetry-setup
         with:
-          python-version: ${{ inputs.python_version || env.PYTHON_VERSION }}
-          poetry-version: ${{ inputs.poetry_version || env.POETRY_VERSION }}
+          python-version: ${{ inputs.python_version }}
+          poetry-version: ${{ inputs.poetry_version }}
 
       - name: Install dependencies
         run: poetry sync --no-root --no-ansi --with evals-summarisation

--- a/.github/workflows/evals-summarisation-smoke-test.yml
+++ b/.github/workflows/evals-summarisation-smoke-test.yml
@@ -1,6 +1,11 @@
 name: Evals Summarisation Smoke Test
 
 on:
+  push:
+    branches:
+      - "feature/**"
+    paths:
+      - .github/workflows/evals-summarisation-smoke-test.yml
   workflow_call:
     inputs: 
       python_version: 

--- a/.github/workflows/evals-summarisation-smoke-test.yml
+++ b/.github/workflows/evals-summarisation-smoke-test.yml
@@ -1,4 +1,4 @@
-name: Evals Summarisation Smoke Test
+name: Summarisation Evals
 
 on:
   push:
@@ -25,13 +25,13 @@ env:
   ENVIRONMENT: test
 
 jobs:
-  smoke-test:
+  summarisation-evals:
     runs-on: ubuntu-latest
     environment: release
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Python and Poetry
         uses: ./.github/actions/python-poetry-setup
@@ -54,7 +54,7 @@ jobs:
         run: poetry run python -m evals.summarisation.src.main --config evals/summarisation/configs/smoke-test.yaml
 
       - name: Upload smoke test output
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: always()
         with:
           name: summarisation-smoke-test-output

--- a/.github/workflows/evals-summarisation-smoke-test.yml
+++ b/.github/workflows/evals-summarisation-smoke-test.yml
@@ -1,16 +1,6 @@
 name: Summarisation Evals
 
 on:
-  workflow_call:
-    inputs: 
-      python_version: 
-        required: false
-        type: string
-        default: '3.12'
-      poetry_version: 
-        required: false
-        type: string
-        default: '2.3.3'
   workflow_dispatch:
     inputs:
       python_version:

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -17,14 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python
-        uses: actions/setup-python@v3
+      - name: Setup Python and Poetry
+        uses: ./.github/actions/python-poetry-setup
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Set up Poetry
-        uses: abatilo/actions-poetry@v2
-        with:
           poetry-version: ${{ env.POETRY_VERSION }}
 
       - name: Install dependencies


### PR DESCRIPTION
# Overview
Add CI pipeline for summarisation evals smoke test. Creates reusable GitHub Actions workflow that runs on-demand to validate summarisation eval functionality with 2 DialogSum examples.

## JIRA Ticket
https://mhclgdigital.atlassian.net/browse/AIILG-200

## Changes

- Created evals-summarisation-smoke-test.yml - reusable workflow for smoke test
- Created python-poetry-setup/action.yml - composite action for Python/Poetry setup with caching
- Refactored backend-tests.yml and type-check.yml to use new composite action
- Configured workflow with manual dispatch trigger (on-demand only, not required for PRs)
- Added Azure OpenAI secrets configuration for LLM API access

## Acceptance Criteria (AC)

- [x] AC1: Smoke test workflow can be triggered manually via workflow_dispatch
- [x] AC2: Workflow follows same patterns as existing Python workflows (backend-tests)
- [x] AC3: Common Python/Poetry setup extracted to reusable composite action
- [x] AC4: Workflow has access to required Azure OpenAI secrets

---

## Testing (if applicable)

- **Automated**: Workflow can be tested via manual dispatch in GitHub Actions UI
- **Manual**: Verify workflow structure matches backend-tests pattern, composite action reduces duplication

## Notes / Additional Information (optional)

- Workflow is **disabled** in main tests pipeline (`if: false` removed, not called at all) - only runs on manual trigger
- Requires GitHub secrets: `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT`, `AZURE_DEPLOYMENT`, `AZURE_API_VERSION`
- Composite action reduces ~20 lines of duplication per workflow
- Smoke test runs 2 examples from DialogSum dataset, outputs uploaded as artifacts (7-day retention)