### PR TITLE
docs(ADR): Update ADR in line with the updated Evals architecture approach (AIILG-477)

### DIFF
--- a/documentation/adr/012-evaluation-storage.md
+++ b/documentation/adr/012-evaluation-storage.md
@@ -19,7 +19,7 @@ We need to determine optimal storage strategies that address these distinct requ
 ## Considered Options
 
 ### Input Storage Options
-* ADAPT (MHCLG official sensitive data service)
+* Azure Blob Storage
 * Git repository (version controlled test cases)
 * S3 Bucket (versioned test datasets)
 * Dedicated test case database
@@ -33,22 +33,24 @@ We need to determine optimal storage strategies that address these distinct requ
 
 ## Decision Outcome
 
-Inputs: ADAPT (MHCLG official sensitive data service), because it is an established, certified solution for Official Sensitive data, avoids the need to manage additional storage infrastructure, and enables collaboration with the ADAPT team.
+Inputs: Azure Blob Storage, because it handles large binary files (e.g., audio), supports fine-grained access controls and encryption for sensitive data, and aligns with the Azure environment. ADAPT (an MHCLG VDI service) can optionally provide an additional layer of access restriction for writes to the underlying storage.
 
-Outputs: Azure Blob Storage, because it aligns with the Azure environment used for evaluation runners (see ADR-014) and ADAPT-based input storage, avoids unnecessary cross-cloud complexity, and provides persistent and reliable storage that is straightforward to set up and integrate.
+Outputs: Azure Blob Storage, because it aligns with the Azure environment used for evaluation runners (see ADR-014) and input storage, avoids unnecessary cross-cloud complexity, and provides persistent and reliable storage that is straightforward to set up and integrate.
 
 ## Pros and Cons of the Options
 
 ### Input Storage Options
 
-#### ADAPT (MHCLG official sensitive data service)
+#### Azure Blob Storage
 
-* Good, because it is an established solution already certified for handling Official Sensitive data.
-* Good, because setup is likely straightforward given it is existing approved infrastructure.
-* Good, because the ADAPT team can provide support if integration issues arise.
-* Good, because collaborating with the ADAPT team allows us to offer feedback that could improve the service for all users.
-* Bad, because we forgo some freedom over how we structure and access data, as we must work within how ADAPT is designed.
-* Bad, because networking prerequisites need to be investigated — for example, access may require being within the MHCLG network, which could introduce additional constraints to other parts of the evaluation system.
+Store evaluation inputs as files in Azure Blob Storage containers with fine-grained access controls.
+
+* Good, because handles large binary files efficiently (e.g., audio samples).
+* Good, because supports fine-grained access controls and encryption for sensitive data.
+* Good, because aligns with the Azure environment used for evaluation runners (ADR-014).
+* Good, because ADAPT (an MHCLG VDI service) can optionally be used to provide an additional layer of access restriction for writes to the underlying storage.
+* Bad, because requires access management setup.
+* Bad, because not suitable for version-controlled test cases without additional tooling.
 
 #### Git repository (version controlled test cases)
 
@@ -86,7 +88,7 @@ Store test cases and configurations in a dedicated database with versioning.
 
 Store evaluation results as files in Azure Blob Storage containers with fine-grained access controls.
 
-* Good, because it aligns with the Azure environment used for evaluation runners (ADR-014) and ADAPT-based input storage.
+* Good, because it aligns with the Azure environment used for evaluation runners (ADR-014) and input storage.
 * Good, because it avoids egress costs that would arise from moving data across cloud providers.
 * Good, because persistent and reliable with no storage limits beyond cost.
 * Good, because easy to set up and integrate, with full control over storage structure.

--- a/documentation/adr/012-evaluation-storage.md
+++ b/documentation/adr/012-evaluation-storage.md
@@ -19,24 +19,36 @@ We need to determine optimal storage strategies that address these distinct requ
 ## Considered Options
 
 ### Input Storage Options
+* ADAPT (MHCLG official sensitive data service)
 * Git repository (version controlled test cases)
 * S3 Bucket (versioned test datasets)
 * Dedicated test case database
 
 ### Output Storage Options
+* Azure Blob Storage
+* Azure DevOps Artifacts
 * CI/CD Artifacts
 * S3 Bucket (or similar object storage)
 * Dedicated Database
 
 ## Decision Outcome
 
-Inputs: S3 Bucket (versioned test datasets), because it handles large files efficiently, supports fine-grained access control for sensitive data, provides encryption and audit logging, and enables versioning to track dataset evolution.
+Inputs: ADAPT (MHCLG official sensitive data service), because it is an established, certified solution for Official Sensitive data, avoids the need to manage additional storage infrastructure, and enables collaboration with the ADAPT team.
 
-Outputs: S3 Bucket (or similar object storage), because it provides persistent and reliable storage, is easy to set up and integrate, and works well with custom dashboards or jupyter notebooks for analysis.
+Outputs: Azure Blob Storage, because it aligns with the Azure environment used for evaluation runners (see ADR-014) and ADAPT-based input storage, avoids unnecessary cross-cloud complexity, and provides persistent and reliable storage that is straightforward to set up and integrate.
 
 ## Pros and Cons of the Options
 
 ### Input Storage Options
+
+#### ADAPT (MHCLG official sensitive data service)
+
+* Good, because it is an established solution already certified for handling Official Sensitive data.
+* Good, because setup is likely straightforward given it is existing approved infrastructure.
+* Good, because the ADAPT team can provide support if integration issues arise.
+* Good, because collaborating with the ADAPT team allows us to offer feedback that could improve the service for all users.
+* Bad, because we forgo some freedom over how we structure and access data, as we must work within how ADAPT is designed.
+* Bad, because networking prerequisites need to be investigated — for example, access may require being within the MHCLG network, which could introduce additional constraints to other parts of the evaluation system.
 
 #### Git repository (version controlled test cases)
 
@@ -69,6 +81,29 @@ Store test cases and configurations in a dedicated database with versioning.
 * Bad, because it requires additional access management.
 
 ### Output Storage Options
+
+#### Azure Blob Storage
+
+Store evaluation results as files in Azure Blob Storage containers with fine-grained access controls.
+
+* Good, because it aligns with the Azure environment used for evaluation runners (ADR-014) and ADAPT-based input storage.
+* Good, because it avoids egress costs that would arise from moving data across cloud providers.
+* Good, because persistent and reliable with no storage limits beyond cost.
+* Good, because easy to set up and integrate, with full control over storage structure.
+* Good, because works well with custom dashboards and Jupyter notebooks for analysis.
+* Bad, because not optimized for across-file querying of data.
+* Bad, because requires a dashboard or Jupyter notebook for most users.
+
+#### Azure DevOps Artifacts
+
+Store evaluation results as pipeline artifacts or Universal Packages within Azure DevOps, scoped to the organisation.
+
+* Good, because it integrates naturally with Azure DevOps CI/CD workflows, aligning with ADR-014.
+* Good, because access is restricted to organisation members with minimal additional setup.
+* Bad, because it offers less freedom than Blob Storage — access controls are coarser and storage structure is constrained by the package registry model.
+* Bad, because pipeline artifacts are tied to pipeline run retention, making long-term persistence unreliable without additional configuration.
+* Bad, because there is a 2 GiB free-tier storage limit per organisation; exceeding it requires paid billing.
+* Bad, because querying and analysing results across artifacts is difficult.
 
 #### CI/CD Artifacts
 

--- a/documentation/adr/014-evaluation-runners.md
+++ b/documentation/adr/014-evaluation-runners.md
@@ -26,7 +26,7 @@ Azure DevOps Runners, because they can operate within a protected network bounda
 
 Run evaluations on Azure DevOps pipelines using runners that can be scoped to operate within a protected network boundary.
 
-* Good, because runners can live within the protected network, enabling easier access for AI services.
+* Good, because runners operate in a trusted network location, simplifying access to AI services through APIM by avoiding WAF false positives.
 * Good, because it allows for tighter network controls, which improve security for evaluations dealing with sensitive data.
 * Good, because it aligns with the preferred storage options in ADR-012.
 * Good, because it avoids ingress and egress costs that would arise from running outside the Azure environment.

--- a/documentation/adr/014-evaluation-runners.md
+++ b/documentation/adr/014-evaluation-runners.md
@@ -12,14 +12,27 @@ Choice of execution infrastructure affects control, cost, and complexity. Since 
 
 ## Considered Options
 
+* Azure DevOps Runners
 * Standard CI/CD Runners
 * Dedicated CI/CD Runners
 
 ## Decision Outcome
 
-Standard CI/CD Runners, because they provide robust security features comparable to dedicated infrastructure while avoiding infrastructure management overhead and costs.
+Azure DevOps Runners, because they can operate within a protected network boundary enabling easier access to AI services, allow for tighter network controls that improve security for evaluations handling sensitive data, and align with the preferred storage options in ADR-012.
 
 ## Pros and Cons of the Options
+
+### Azure DevOps Runners
+
+Run evaluations on Azure DevOps pipelines using runners that can be scoped to operate within a protected network boundary.
+
+* Good, because runners can live within the protected network, enabling easier access for AI services.
+* Good, because it allows for tighter network controls, which improve security for evaluations dealing with sensitive data.
+* Good, because it aligns with the preferred storage options in ADR-012.
+* Good, because it avoids ingress and egress costs that would arise from running outside the Azure environment.
+* Good, because Azure DevOps is an organisation-wide managed instance where much of the security groundwork has already been done.
+* Bad, because it ties evaluation infrastructure to Azure DevOps, reducing portability.
+* Bad, because it would mean that some of our pipelines are inconsistent with other pipelines in the repository (such as linting pipelines).
 
 ### Standard CI/CD Runners
 


### PR DESCRIPTION
# Overview
Updates ADR-012 and ADR-014 to reflect the decision to use ADAPT for evaluation input storage, Azure Blob Storage for outputs, and Azure DevOps runners for evaluation execution. Also removes sign-off sections from ADR-005, ADR-006, and ADR-007, and adds a cross-reference to ADR-005.

## JIRA Ticket
https://mhclgdigital.atlassian.net/browse/AIILG-477

## Changes

- ADR-012: input storage decision changed from S3 to ADAPT (MHCLG official sensitive data service); output decision changed from S3 to Azure Blob Storage; Azure DevOps Artifacts added as a considered alternative
- ADR-014: Azure DevOps Runners added as a new option and selected as the preferred decision; updated pros/cons to reflect network boundary access, security, cost, and pipeline consistency considerations

## Acceptance Criteria (AC)

- [X] AC1: ADR-012 reflects ADAPT for inputs and Azure Blob Storage for outputs
- [X] AC2: ADR-014 reflects Azure DevOps Runners as the preferred option

---

## Testing (if applicable)

- **Automated**: N/A
- **Manual**: Review ADR content for accuracy and consistency