### PR TITLE
feat(common): implement new client secret apim token provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,11 @@ AZURE_APIM_URL=https://{{host}}.gov.uk/{{product_name}}/
 AZURE_APIM_API_VERSION=2024-10-21
 AZURE_APIM_ACCESS_TOKEN=placeholder
 AZURE_APIM_SUBSCRIPTION_KEY=placeholder
+AZURE_APIM_AUTH_METHOD=static_token
+AZURE_APIM_TENANT_ID=not_needed_for_static_token
+AZURE_APIM_CLIENT_ID=not_needed_for_static_token
+AZURE_APIM_CLIENT_SECRET=not_needed_for_static_token
+AZURE_APIM_SCOPE=not_needed_for_static_token
 
 # === select transcription services ===
 TRANSCRIPTION_SERVICES=["azure_stt_synchronous","azure_stt_batch"]

--- a/common/llm/adapters/azure_apim.py
+++ b/common/llm/adapters/azure_apim.py
@@ -4,9 +4,12 @@ import asyncio
 import logging
 import re
 from collections.abc import Awaitable, Callable
+from functools import cache
+from typing import Protocol
 
-from openai import APIConnectionError, APIError, AsyncOpenAI, RateLimitError
-from openai.types.chat import ChatCompletion
+from azure.identity.aio import ClientSecretCredential
+from openai import APIConnectionError, APIError, AsyncOpenAI, AuthenticationError, RateLimitError
+from openai.types.chat import ChatCompletion, ParsedChatCompletion
 from openai.types.chat.chat_completion import Choice
 
 from .base import ModelAdapter
@@ -18,35 +21,109 @@ logger = logging.getLogger(__name__)
 MAX_RETRIES = 6
 
 
+@cache
+def get_azure_client_secret_token_provider(
+    tenant_id: str, client_id: str, client_secret: str, scope: str
+) -> AzureTokenProvider:
+    """
+    Returns an AzureClientSecretTokenProvider instance for the configured tenant/client. Caches providers.
+    """
+    return AzureClientSecretCredentialTokenProvider(tenant_id, client_id, client_secret, scope)
+
+
+class AzureTokenProvider(Protocol):
+    async def get_token(self) -> str: ...
+    async def invalidate_token(self) -> None: ...
+
+
+class AzureStaticTokenProvider:
+    """
+    Basic token provider which always returns the token it was initialised with
+    """
+
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    async def get_token(self) -> str:
+        return self._token
+
+    async def invalidate_token(self) -> None:
+        pass
+
+
+class AzureClientSecretCredentialTokenProvider:
+    """
+    Handles getting Azure Tokens via ClientSecretCredential
+    """
+
+    def __init__(self, tenant_id: str, client_id: str, client_secret: str, scope: str) -> None:
+        self._refresh_lock = asyncio.Lock()
+        self._token: str | None = None
+        self._token_valid: bool = False
+        self._azure_credential = ClientSecretCredential(tenant_id, client_id, client_secret)
+        self.scope = scope
+
+    async def _refresh_token(self) -> str:
+        async with self._refresh_lock:
+            if self._token_valid and self._token:
+                return self._token
+            result = await self._azure_credential.get_token(self.scope)
+            self._token = result.token
+            self._token_valid = True
+            return self._token
+
+    async def get_token(self) -> str:
+        if self._token_valid and self._token:
+            return self._token
+        return await self._refresh_token()
+
+    async def invalidate_token(self) -> None:
+        self._token_valid = False
+
+
 class AzureAPIMModelAdapter(ModelAdapter):
     def __init__(
         self,
         url: str,
         model: str,
         api_version: str,
-        access_token: str,
         subscription_key: str,
+        token_provider: AzureTokenProvider,
     ) -> None:
         self._model = model
         self._api_version = api_version
-        self.async_apim_client = AsyncOpenAI(
-            base_url=url + self._model,
-            api_key=access_token,
-            default_headers={
-                "Ocp-Apim-Subscription-Key": subscription_key,
-            },
-            max_retries=0,
-        )
+        self._url = url
+        self._subscription_key = subscription_key
+        self._token_provider = token_provider
+        self._cached_async_apim_client: AsyncOpenAI | None = None
+
+    async def _get_apim_client(self) -> AsyncOpenAI:
+        token = await self._token_provider.get_token()
+        if self._cached_async_apim_client is None or self._cached_async_apim_client.api_key != token:
+            self._cached_async_apim_client = AsyncOpenAI(
+                base_url=self._url + self._model,  # APIM URL expects model here
+                api_key=token,
+                default_headers={
+                    "Ocp-Apim-Subscription-Key": self._subscription_key,
+                },
+                max_retries=0,
+            )
+        return self._cached_async_apim_client
 
     async def structured_chat[T](self, messages: list[dict[str, str]], response_format: type[T]) -> T:
         openai_messages = [convert_to_openai_message(msg) for msg in messages]
-        response = await self._call_with_retry(
-            lambda: self.async_apim_client.beta.chat.completions.parse(
+
+        async def call() -> ParsedChatCompletion[T]:
+            client = await self._get_apim_client()
+            return await client.beta.chat.completions.parse(
                 model=self._model,
                 messages=openai_messages,
                 response_format=response_format,
                 extra_query={"api-version": self._api_version},
-            ),
+            )
+
+        response = await self._call_with_retry(
+            call,
             "structured_chat",
         )
         parsed = response.choices[0].message.parsed
@@ -60,14 +137,19 @@ class AzureAPIMModelAdapter(ModelAdapter):
 
     async def chat(self, messages: list[dict[str, str]]) -> str:
         openai_messages = [convert_to_openai_message(msg) for msg in messages]
-        response = await self._call_with_retry(
-            lambda: self.async_apim_client.chat.completions.create(
+
+        async def call() -> ChatCompletion:
+            client = await self._get_apim_client()
+            return await client.chat.completions.create(
                 model=self._model,
                 messages=openai_messages,
                 temperature=TEMPERATURE,
                 max_tokens=MAX_TOKENS,
                 extra_query={"api-version": self._api_version},
-            ),
+            )
+
+        response = await self._call_with_retry(
+            call,
             "chat",
         )
         choice = response.choices[0]
@@ -101,6 +183,17 @@ class AzureAPIMModelAdapter(ModelAdapter):
                 if attempt == MAX_RETRIES - 1:
                     raise
                 await asyncio.sleep(wait_time)
+            except AuthenticationError:
+                logger.warning(
+                    "%s - authentication error, refreshing token and retrying (attempt %d/%d)",
+                    method_name,
+                    attempt + 1,
+                    MAX_RETRIES,
+                )
+                await self._token_provider.invalidate_token()
+                self._cached_async_apim_client = await self._get_apim_client()
+                if attempt == MAX_RETRIES - 1:
+                    raise
             except (APIConnectionError, APIError) as e:
                 logger.error("%s - %s: %s", method_name, type(e).__name__, str(e))
                 raise

--- a/common/llm/client.py
+++ b/common/llm/client.py
@@ -11,6 +11,11 @@ from tenacity import (
 )
 
 from common.llm.adapters import AzureAPIMModelAdapter, GeminiModelAdapter, ModelAdapter, OpenAIModelAdapter
+from common.llm.adapters.azure_apim import (
+    AzureStaticTokenProvider,
+    AzureTokenProvider,
+    get_azure_client_secret_token_provider,
+)
 from common.prompts import get_hallucination_detection_messages
 from common.settings import get_settings
 from common.types import LLMHallucination, LLMHallucinationList
@@ -61,6 +66,35 @@ class ChatBot:
         self.messages.extend(messages)
         self.messages.append({"role": "assistant", "content": response.model_dump_json()})
         return response
+
+
+def _build_azure_apim_token_provider() -> AzureTokenProvider:
+    if settings.AZURE_APIM_AUTH_METHOD == "client_secret":
+        if not settings.AZURE_APIM_TENANT_ID:
+            msg = "AZURE_APIM_TENANT_ID is required for azure_apim client_secret auth"
+            raise ValueError(msg)
+        if not settings.AZURE_APIM_CLIENT_ID:
+            msg = "AZURE_APIM_CLIENT_ID is required for azure_apim client_secret auth"
+            raise ValueError(msg)
+        if not settings.AZURE_APIM_CLIENT_SECRET:
+            msg = "AZURE_APIM_CLIENT_SECRET is required for azure_apim client_secret auth"
+            raise ValueError(msg)
+        if not settings.AZURE_APIM_SCOPE:
+            msg = "AZURE_APIM_SCOPE is required for azure_apim client_secret auth"
+            raise ValueError(msg)
+        return get_azure_client_secret_token_provider(
+            settings.AZURE_APIM_TENANT_ID,
+            settings.AZURE_APIM_CLIENT_ID,
+            settings.AZURE_APIM_CLIENT_SECRET,
+            settings.AZURE_APIM_SCOPE,
+        )
+    if settings.AZURE_APIM_AUTH_METHOD == "static_token":
+        if not settings.AZURE_APIM_ACCESS_TOKEN:
+            msg = "AZURE_APIM_ACCESS_TOKEN is required for azure_apim static_token auth"
+            raise ValueError(msg)
+        return AzureStaticTokenProvider(settings.AZURE_APIM_ACCESS_TOKEN)
+    msg = "AZURE_APIM_AUTH_METHOD is required, use either 'static_token' or 'client_secret'"
+    raise ValueError(msg)
 
 
 def create_chatbot(model_type: str, model_name: str, temperature: float) -> ChatBot:
@@ -125,19 +159,18 @@ def create_chatbot(model_type: str, model_name: str, temperature: float) -> Chat
         if not settings.AZURE_APIM_API_VERSION:
             msg = "AZURE_APIM_API_VERSION is required for azure_apim model"
             raise ValueError(msg)
-        if not settings.AZURE_APIM_ACCESS_TOKEN:
-            msg = "AZURE_APIM_ACCESS_TOKEN is required for azure_apim model"
-            raise ValueError(msg)
         if not settings.AZURE_APIM_SUBSCRIPTION_KEY:
             msg = "AZURE_APIM_SUBSCRIPTION_KEY is required for azure_apim model"
             raise ValueError(msg)
+
+        token_provider = _build_azure_apim_token_provider()
 
         return ChatBot(
             AzureAPIMModelAdapter(
                 url=settings.AZURE_APIM_URL,
                 model=model_name,
                 api_version=settings.AZURE_APIM_API_VERSION,
-                access_token=settings.AZURE_APIM_ACCESS_TOKEN,
+                token_provider=token_provider,
                 subscription_key=settings.AZURE_APIM_SUBSCRIPTION_KEY,
             )
         )

--- a/common/settings.py
+++ b/common/settings.py
@@ -1,5 +1,6 @@
 import logging
 from functools import lru_cache
+from typing import Literal
 
 import dotenv
 from i_dot_ai_utilities.logging.structured_logger import StructuredLogger
@@ -71,8 +72,19 @@ class Settings(BaseSettings):
     # if using Azure APIM
     AZURE_APIM_URL: str | None = Field(description="Base URL for Minute's Azure APIM LLM.", default=None)
     AZURE_APIM_API_VERSION: str | None = Field(description="Azure APIM API version, <yyyy-mm-dd>", default=None)
-    AZURE_APIM_ACCESS_TOKEN: str | None = Field(description="Access token for Azure APIM", default=None)
     AZURE_APIM_SUBSCRIPTION_KEY: str | None = Field(description="Subscription key for Azure APIM", default=None)
+    AZURE_APIM_AUTH_METHOD: Literal["client_secret", "static_token"] | None = Field(
+        description="APIM auth method: 'client_secret' or 'static_token'", default=None
+    )
+    # if using 'client_secret' for AZURE_APIM_AUTH_METHOD
+    AZURE_APIM_TENANT_ID: str | None = Field(description="Azure tenant ID for APIM client secret auth", default=None)
+    AZURE_APIM_CLIENT_ID: str | None = Field(description="Azure client ID for APIM client secret auth", default=None)
+    AZURE_APIM_CLIENT_SECRET: str | None = Field(
+        description="Azure client secret for APIM client secret auth", default=None
+    )
+    AZURE_APIM_SCOPE: str | None = Field(description="OAuth scope for APIM client secret auth", default=None)
+    # if using 'static_token' for AZURE_APIM_AUTH_METHOD
+    AZURE_APIM_ACCESS_TOKEN: str | None = Field(description="Access token for Azure APIM", default=None)
 
     # if using Gemini
     GOOGLE_APPLICATION_CREDENTIALS: str | None = Field(

--- a/evals/summarisation/src/common/adapter_factory.py
+++ b/evals/summarisation/src/common/adapter_factory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from common.llm.adapters import AzureAPIMModelAdapter
+from common.llm.adapters.azure_apim import AzureStaticTokenProvider
 from common.settings import get_settings
 
 
@@ -24,6 +25,6 @@ def build_azure_apim_adapter() -> AzureAPIMModelAdapter:
         url=settings.AZURE_APIM_URL,
         model=settings.BEST_LLM_MODEL_NAME,
         api_version=settings.AZURE_APIM_API_VERSION,
-        access_token=settings.AZURE_APIM_ACCESS_TOKEN,
+        token_provider=AzureStaticTokenProvider(settings.AZURE_APIM_ACCESS_TOKEN),
         subscription_key=settings.AZURE_APIM_SUBSCRIPTION_KEY,
     )

--- a/get-apim-token.sh
+++ b/get-apim-token.sh
@@ -15,11 +15,11 @@ if [ ! -f "$ENV_FILE" ]; then
     exit 1
 fi
 
-# Extract AZURE_TOKEN_SCOPE from .env (avoiding sourcing to prevent parsing errors)
-TOKEN_SCOPE=$(grep "^AZURE_TOKEN_SCOPE=" "$ENV_FILE" | cut -d'=' -f2- | tr -d '"' | tr -d "'")
+# Extract AZURE_APIM_SCOPE from .env (avoiding sourcing to prevent parsing errors)
+TOKEN_SCOPE=$(grep "^AZURE_APIM_SCOPE=" "$ENV_FILE" | cut -d'=' -f2- | tr -d '"' | tr -d "'")
 
 if [ -z "$TOKEN_SCOPE" ]; then
-    echo "Error: AZURE_TOKEN_SCOPE not set in $ENV_FILE" >&2
+    echo "Error: AZURE_APIM_SCOPE not set in $ENV_FILE" >&2
     exit 1
 fi
 

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -207,6 +207,12 @@ module "ecs" {
 
   azure_speech_key_arn    = module.secrets.azure_speech_key_arn
   azure_speech_region_arn = module.secrets.azure_speech_region_arn
+
+  azure_apim_tenant_id_arn        = module.secrets.azure_apim_tenant_id_arn
+  azure_apim_client_id_arn        = module.secrets.azure_apim_client_id_arn
+  azure_apim_client_secret_arn    = module.secrets.azure_apim_client_secret_arn
+  azure_apim_scope_arn            = module.secrets.azure_apim_scope_arn
+  azure_apim_subscription_key_arn = module.secrets.azure_apim_subscription_key_arn
 }
 
 module "uploads_bucket" {

--- a/terraform/modules/ecs/task_definition.tf
+++ b/terraform/modules/ecs/task_definition.tf
@@ -62,16 +62,16 @@ locals {
       value = "transcriptions"
     }, {
       name = "FAST_LLM_PROVIDER"
-      value = "gemini"
+      value = "azure_apim"
     }, {
       name = "FAST_LLM_MODEL_NAME"
-      value = "gemini-2.5-flash-lite"
+      value = "gpt-4o"
     }, {
       name = "BEST_LLM_PROVIDER"
-      value = "gemini"
+      value = "azure_apim"
     }, {
       name = "BEST_LLM_MODEL_NAME"
-      value = "gemini-2.5-flash"
+      value = "gpt-4o"
     }, {
       name  = "ALB_ARN"
       value = var.alb_arn
@@ -84,6 +84,15 @@ locals {
     }, {
       name  = "AWS_ACCOUNT_ID"
       value = data.aws_caller_identity.current.account_id
+    }, {
+      name  = "AZURE_APIM_AUTH_METHOD"
+      value = "client_secret"
+    }, {
+    name  = "AZURE_APIM_URL"
+    value = "https://api.azc.test.communities.gov.uk/minute/"
+    }, {
+    name  = "AZURE_APIM_API_VERSION"
+    value = "2024-10-21"
     },
   ]
   shared_worker_backend_secrets = [
@@ -98,6 +107,26 @@ locals {
     {
       name      = "AZURE_SPEECH_REGION"
       valueFrom = var.azure_speech_region_arn
+    },
+    {
+      name      = "AZURE_APIM_TENANT_ID"
+      valueFrom = var.azure_apim_tenant_id_arn
+    },
+    {
+      name      = "AZURE_APIM_CLIENT_ID"
+      valueFrom = var.azure_apim_client_id_arn
+    },
+    {
+      name      = "AZURE_APIM_CLIENT_SECRET"
+      valueFrom = var.azure_apim_client_secret_arn
+    },
+    {
+      name      = "AZURE_APIM_SCOPE"
+      valueFrom = var.azure_apim_scope_arn
+    },
+    {
+      name      = "AZURE_APIM_SUBSCRIPTION_KEY"
+      valueFrom = var.azure_apim_subscription_key_arn
     },
   ]
   frontend_environment_variables = [

--- a/terraform/modules/ecs/variables.tf
+++ b/terraform/modules/ecs/variables.tf
@@ -199,6 +199,31 @@ variable "azure_speech_region_arn" {
   type        = string
 }
 
+variable "azure_apim_tenant_id_arn" {
+  description = "ARN of the SSM parameter containing the Azure APIM tenant ID"
+  type        = string
+}
+
+variable "azure_apim_client_id_arn" {
+  description = "ARN of the SSM parameter containing the Azure APIM client ID"
+  type        = string
+}
+
+variable "azure_apim_client_secret_arn" {
+  description = "ARN of the SSM parameter containing the Azure APIM client secret"
+  type        = string
+}
+
+variable "azure_apim_scope_arn" {
+  description = "ARN of the SSM parameter containing the Azure APIM OAuth scope"
+  type        = string
+}
+
+variable "azure_apim_subscription_key_arn" {
+  description = "ARN of the SSM parameter containing the Azure APIM subscription key"
+  type        = string
+}
+
 variable "lb_listener_exists" {
   description = "Indicates whether the load balancer listener has been created"
   type        = bool

--- a/terraform/modules/secrets/iam.tf
+++ b/terraform/modules/secrets/iam.tf
@@ -60,6 +60,11 @@ resource "aws_iam_role_policy" "secret_access" {
         Resource = [
           aws_ssm_parameter.azure_speech_key.arn,
           aws_ssm_parameter.azure_speech_region.arn,
+          aws_ssm_parameter.azure_apim_tenant_id.arn,
+          aws_ssm_parameter.azure_apim_client_id.arn,
+          aws_ssm_parameter.azure_apim_client_secret.arn,
+          aws_ssm_parameter.azure_apim_scope.arn,
+          aws_ssm_parameter.azure_apim_subscription_key.arn,
         ]
       }
     ]

--- a/terraform/modules/secrets/outputs.tf
+++ b/terraform/modules/secrets/outputs.tf
@@ -33,3 +33,28 @@ output "internal_access_oidc_client_secret_name" {
   description = "SSM parameter name for the Gov Internal Access OIDC client secret."
   value       = aws_ssm_parameter.oidc_client_secret.name
 }
+
+output "azure_apim_tenant_id_arn" {
+  description = "ARN of the SSM parameter containing the Azure APIM tenant ID"
+  value       = aws_ssm_parameter.azure_apim_tenant_id.arn
+}
+
+output "azure_apim_client_id_arn" {
+  description = "ARN of the SSM parameter containing the Azure APIM client ID"
+  value       = aws_ssm_parameter.azure_apim_client_id.arn
+}
+
+output "azure_apim_client_secret_arn" {
+  description = "ARN of the SSM parameter containing the Azure APIM client secret"
+  value       = aws_ssm_parameter.azure_apim_client_secret.arn
+}
+
+output "azure_apim_scope_arn" {
+  description = "ARN of the SSM parameter containing the Azure APIM OAuth scope"
+  value       = aws_ssm_parameter.azure_apim_scope.arn
+}
+
+output "azure_apim_subscription_key_arn" {
+  description = "ARN of the SSM parameter containing the Azure APIM subscription key"
+  value       = aws_ssm_parameter.azure_apim_subscription_key.arn
+}

--- a/terraform/modules/secrets/secrets.tf
+++ b/terraform/modules/secrets/secrets.tf
@@ -46,6 +46,66 @@ resource "aws_ssm_parameter" "azure_speech_region" {
   }
 }
 
+resource "aws_ssm_parameter" "azure_apim_tenant_id" {
+  type        = "SecureString"
+  key_id      = aws_kms_key.local_transcribe_secrets.arn
+  name        = "/local-transcribe/azure/apim_tenant_id"
+  description = "Azure tenant ID for APIM client secret auth"
+  value       = "placeholder" # Update value in SSM - Do not hardcode
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+resource "aws_ssm_parameter" "azure_apim_client_id" {
+  type        = "SecureString"
+  key_id      = aws_kms_key.local_transcribe_secrets.arn
+  name        = "/local-transcribe/azure/apim_client_id"
+  description = "Azure client ID for APIM client secret auth"
+  value       = "placeholder" # Update value in SSM - Do not hardcode
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+resource "aws_ssm_parameter" "azure_apim_client_secret" {
+  type        = "SecureString"
+  key_id      = aws_kms_key.local_transcribe_secrets.arn
+  name        = "/local-transcribe/azure/apim_client_secret"
+  description = "Azure client secret for APIM client secret auth"
+  value       = "placeholder" # Update value in SSM - Do not hardcode
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+resource "aws_ssm_parameter" "azure_apim_scope" {
+  type        = "SecureString"
+  key_id      = aws_kms_key.local_transcribe_secrets.arn
+  name        = "/local-transcribe/azure/apim_scope"
+  description = "OAuth scope for APIM client secret auth"
+  value       = "placeholder" # Update value in SSM - Do not hardcode
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
+resource "aws_ssm_parameter" "azure_apim_subscription_key" {
+  type        = "SecureString"
+  key_id      = aws_kms_key.local_transcribe_secrets.arn
+  name        = "/local-transcribe/azure/apim_subscription_key"
+  description = "Azure APIM subscription key"
+  value       = "placeholder" # Update value in SSM - Do not hardcode
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
 resource "aws_secretsmanager_secret" "database_password" {
   name                    = "tf-${var.environment_name}-local-transcribe-database-password"
   description             = "Password for local-transcribe backend database user"

--- a/tests/common/llm/test_azure_apim_token_provider.py
+++ b/tests/common/llm/test_azure_apim_token_provider.py
@@ -1,0 +1,56 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from common.llm.adapters.azure_apim import AzureClientSecretCredentialTokenProvider
+
+
+@pytest.fixture
+def provider():
+    token_provider = AzureClientSecretCredentialTokenProvider(
+        tenant_id="tenant", client_id="client", client_secret="secret", scope="https://example.com/.default"
+    )
+
+    # Mock the Azure Credential provider used within AzureClientSecretCredentialTokenProvider
+    token_provider._azure_credential = AsyncMock()  # noqa: SLF001
+    token_provider._azure_credential.get_token = AsyncMock(return_value=MagicMock(token="fake-token"))  # noqa: SLF001
+    return token_provider
+
+
+@pytest.mark.asyncio
+async def test_get_token_fetches_token_on_first_call(provider):
+    token = await provider.get_token()
+
+    assert token == "fake-token"  # noqa: S105
+    provider._azure_credential.get_token.assert_called_once_with("https://example.com/.default")  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_get_token_returns_cached_token_without_re_fetching(provider):
+    await provider.get_token()
+    await provider.get_token()
+
+    provider._azure_credential.get_token.assert_called_once()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_invalidate_token_causes_refetch(provider):
+    provider._azure_credential.get_token = AsyncMock(  # noqa: SLF001
+        side_effect=[MagicMock(token="token-1"), MagicMock(token="token-2")]
+    )
+
+    await provider.get_token()
+    await provider.invalidate_token()
+    token = await provider.get_token()
+
+    assert token == "token-2"  # noqa: S105
+    assert provider._azure_credential.get_token.call_count == 2  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_concurrent_get_token_calls_only_fetch_once(provider):
+    tokens = await asyncio.gather(provider.get_token(), provider.get_token())
+
+    assert all(t == "fake-token" for t in tokens)
+    provider._azure_credential.get_token.assert_called_once()  # noqa: SLF001

--- a/tests/evals/summarisation/test_adapter_factory.py
+++ b/tests/evals/summarisation/test_adapter_factory.py
@@ -42,6 +42,6 @@ def test_build_azure_apim_adapter_success(monkeypatch):
     assert isinstance(adapter, type(adapter))
     assert adapter._model == model_name  # noqa: SLF001
     assert adapter._api_version == api_version  # noqa: SLF001
-    assert adapter.async_apim_client is not None
-    assert str(adapter.async_apim_client.base_url).rstrip("/") == f"{base_url.rstrip('/')}/{model_name}"
-    assert "Ocp-Apim-Subscription-Key" in adapter.async_apim_client.default_headers
+    assert adapter._cached_async_apim_client is not None  # noqa: SLF001
+    assert str(adapter._cached_async_apim_client.base_url).rstrip("/") == f"{base_url.rstrip('/')}/{model_name}"  # noqa: SLF001
+    assert "Ocp-Apim-Subscription-Key" in adapter._cached_async_apim_client.default_headers  # noqa: SLF001

--- a/tests/evals/summarisation/test_adapter_factory.py
+++ b/tests/evals/summarisation/test_adapter_factory.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from evals.summarisation.src.common.adapter_factory import build_azure_apim_adapter
@@ -38,13 +40,11 @@ def test_build_azure_apim_adapter_success(monkeypatch):
     monkeypatch.setenv("BEST_LLM_MODEL_NAME", model_name)
 
     adapter = build_azure_apim_adapter()
-
-    # Populate the cached client
-    adapter._get_apim_client()  # noqa: SLF001
+    client = asyncio.run(adapter._get_apim_client())  # noqa: SLF001
 
     assert isinstance(adapter, type(adapter))
     assert adapter._model == model_name  # noqa: SLF001
     assert adapter._api_version == api_version  # noqa: SLF001
-    assert adapter._cached_async_apim_client is not None  # noqa: SLF001
-    assert str(adapter._cached_async_apim_client.base_url).rstrip("/") == f"{base_url.rstrip('/')}/{model_name}"  # noqa: SLF001
-    assert "Ocp-Apim-Subscription-Key" in adapter._cached_async_apim_client.default_headers  # noqa: SLF001
+    assert client is not None
+    assert str(client.base_url).rstrip("/") == f"{base_url.rstrip('/')}/{model_name}"
+    assert "Ocp-Apim-Subscription-Key" in client.default_headers

--- a/tests/evals/summarisation/test_adapter_factory.py
+++ b/tests/evals/summarisation/test_adapter_factory.py
@@ -39,6 +39,9 @@ def test_build_azure_apim_adapter_success(monkeypatch):
 
     adapter = build_azure_apim_adapter()
 
+    # Populate the cached client
+    adapter._get_apim_client()  # noqa: SLF001
+
     assert isinstance(adapter, type(adapter))
     assert adapter._model == model_name  # noqa: SLF001
     assert adapter._api_version == api_version  # noqa: SLF001


### PR DESCRIPTION
# Overview
Refactors how the APIM client handles its authentication tokens, and adds a new `AzureClientSecretCredentialTokenProvider` to support using the `ClientSecret` azure authentication provider. This will allow the hosted app (in aws) to connect to apim and automatically renew and acquire authentication tokens.

## JIRA Ticket
https://mhclgdigital.atlassian.net/browse/AIILG-455

## Changes
- Refactor `AzureAPIMModelAdapter` to take a new `AzureTokenProvider`, and implement two new token providers:  
  - `AzureClientSecretCredentialTokenProvider`, obtains APIM tokens automatically via Azure AD client secret credentials - this is for AWS
  - `AzureStaticTokenProvider`, always returns the same token, pass in this token as an env var. Mimics the previous behaviour - and so useful for local dev.
- Add AZURE_APIM_AUTH_METHOD setting to switch between these providers
- Add environment variables: AZURE_APIM_TENANT_ID, AZURE_APIM_CLIENT_ID, AZURE_APIM_CLIENT_SECRET, AZURE_APIM_SCOPE, AZURE_APIM_SUBSCRIPTION_KEY for 
- Store the 5 new secrets in aws ssm parameter store as with the other secrets and pass them into backend and worker ecs task definitions


## Acceptance Criteria (AC)

- [x] AC1: Static token provider reads the token from the `AZURE_APIM_ACCESS_TOKEN` environment variable and supplies it to the `AzureAPIMModelAdapter`
- [x] AC2: Client secret token provider reads credentials from environment variables
- [x] AC3: Client secret token provider stores token from Azure in memory
- [x] AC4: Client secret token provider gets token from Azure if no token exists
- [x] AC5: Client secret token provider gets new token from Azure, on the next call to `get_token` if previous token has been marked invalid
- [x] AC6: Azure token is marked as invalid if a request fails due to `AuthenticationError`
- [x] AC7: If a request to APIM fails due to `AuthenticationError` the request is retried with a new token
- [x] AC8: Client secret token provider transparently, and lazily, handles the lifecycle of the token
- [x] AC9: Client secret token provider is thread-safe, namely avoids the 'thundering herd problem' so the token isn't renewed multiple times (one for each thread) when it expires. The first thread should renew the token and all others should wait for the renewal. 
- [x] AC10: Secrets are securely stored in AWS SSM parameters and securely passed to the ecs services
- [x] AC11: The client secret token provider should be shared between all APIM providers running.  


---

## Testing (if applicable)

- **Automated**: Added unit tests for the client secret token provider.
- **Manual**: Tested both token providers locally.

## Screenshots / UI (optional)
<!-- Before/after if this changes UI. -->

## Notes / Additional Information (optional)
<!-- Anything reviewers should know: migrations, feature flags, monitoring, tech debt, next steps. -->
