### PR TITLE
Fix(db): Sync user_template model to alembic (AIILG-None)

### DIFF
--- a/common/database/postgres_models.py
+++ b/common/database/postgres_models.py
@@ -200,7 +200,11 @@ class UserTemplate(BaseTableMixin, table=True):
     content: str
     description: str = ""
 
-    type: TemplateType = TemplateType.DOCUMENT
+    type: TemplateType = Field(
+        default=TemplateType.DOCUMENT,
+        nullable=False,
+        sa_column_kwargs={"server_default": "DOCUMENT"},
+    )
 
     user_id: UUID | None = Field(default=None, foreign_key="user.id")
 


### PR DESCRIPTION
# Overview
The user_template model has no server_default though the alembic script does. This PR gives the model what the alembic script suggests it should have

## JIRA Ticket
None

## Changes
- Update user_template model

## Acceptance Criteria (AC)
- [ ] AC1:

---

## Testing (if applicable)

- **Manual**: run `poetry run alembic revision --autogenerate -m "checking alembic sync"` and see no new code in the generated migration script (as seen below). 

## Screenshots / UI (optional)
Generating migration script before update to user_template model: 
```
def upgrade() -> None:
    # ### commands auto generated by Alembic - please adjust! ###
    op.alter_column('user_template', 'type',
        existing_type=postgresql.ENUM('DOCUMENT', 'FORM', name='templatetype'),
        server_default=None,
        existing_nullable=False)
    # ### end Alembic commands ###
 
def downgrade() -> None:
# ### commands auto generated by Alembic - please adjust! ###
    op.alter_column('user_template', 'type',
        existing_type=postgresql.ENUM('DOCUMENT', 'FORM', name='templatetype'),
        server_default=sa.text("'DOCUMENT'::templatetype"),
        existing_nullable=False)
# ### end Alembic commands ###
```

Generating migration script once model is synced:
```
def upgrade() -> None:
    # ### commands auto generated by Alembic - please adjust! ###
    pass
    # ### end Alembic commands ###

def downgrade() -> None:
    # ### commands auto generated by Alembic - please adjust! ###
    pass
    # ### end Alembic commands ###
```