### PR TITLE
chore: remove CODEOWNERS (NO-JIRA)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-*       @i-dot-ai/minute-admins


### PR DESCRIPTION
# Overview
Removes the inherited `CODEOWNERS` file. This still listed i-ai as the owners, and is unnecessary now.