### PR TITLE
fix: resolve CI linting errors (AILG-187)

### DIFF
--- a/frontend/components/audio/tab-recorder/tab-recorder.tsx
+++ b/frontend/components/audio/tab-recorder/tab-recorder.tsx
@@ -84,7 +84,6 @@ function TabRecorder({
   const streamRef = useRef<MediaStream | null>(null)
   const screenStreamRef = useRef<MediaStream | null>(null)
   const micStreamRef = useRef<MediaStream | null>(null)
-  const [stream, setStream] = useState<MediaStream | null>(null)
   useTabCloseWarning(isRecording || !!recordedAudio)
 
   const stopAllTracks = useCallback(() => {
@@ -102,7 +101,6 @@ function TabRecorder({
     streamRef.current = null
     micStreamRef.current = null
     mediaRecorderRef.current = null
-    setStream(null)
 
     setIsRecording(false)
     releaseWakeLock()
@@ -222,7 +220,6 @@ function TabRecorder({
         composedStream.addTrack(track)
       })
       streamRef.current = composedStream
-      setStream(composedStream)
 
       // Create a media recorder from the composed stream
       const options = { mimeType: 'audio/webm' }
@@ -351,7 +348,7 @@ function TabRecorder({
           ) : (
             <div className="space-y-4">
               <RecordingControl
-                stream={stream}
+                stream={streamRef.current}
                 isRecording={isRecording}
                 onStopRecording={stopRecording}
                 onPauseStateChange={handlePauseStateChange}

--- a/frontend/components/audio/tab-recorder/tab-recorder.tsx
+++ b/frontend/components/audio/tab-recorder/tab-recorder.tsx
@@ -84,6 +84,7 @@ function TabRecorder({
   const streamRef = useRef<MediaStream | null>(null)
   const screenStreamRef = useRef<MediaStream | null>(null)
   const micStreamRef = useRef<MediaStream | null>(null)
+  const [stream, setStream] = useState<MediaStream | null>(null)
   useTabCloseWarning(isRecording || !!recordedAudio)
 
   const stopAllTracks = useCallback(() => {
@@ -101,6 +102,7 @@ function TabRecorder({
     streamRef.current = null
     micStreamRef.current = null
     mediaRecorderRef.current = null
+    setStream(null)
 
     setIsRecording(false)
     releaseWakeLock()
@@ -220,6 +222,7 @@ function TabRecorder({
         composedStream.addTrack(track)
       })
       streamRef.current = composedStream
+      setStream(composedStream)
 
       // Create a media recorder from the composed stream
       const options = { mimeType: 'audio/webm' }
@@ -348,7 +351,7 @@ function TabRecorder({
           ) : (
             <div className="space-y-4">
               <RecordingControl
-                stream={streamRef.current}
+                stream={stream}
                 isRecording={isRecording}
                 onStopRecording={stopRecording}
                 onPauseStateChange={handlePauseStateChange}

--- a/frontend/hooks/use-mobile.ts
+++ b/frontend/hooks/use-mobile.ts
@@ -1,19 +1,24 @@
-import * as React from 'react'
+import { useEffect, useState } from 'react'
 
 const MOBILE_BREAKPOINT = 768
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+  const [isMobile, setIsMobile] = useState<boolean>(() => {
+    return typeof window !== 'undefined'
+      ? window.innerWidth < MOBILE_BREAKPOINT
+      : false
+  })
 
-  React.useEffect(() => {
+  useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+
     const onChange = () => {
       setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
     }
+
     mql.addEventListener('change', onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
     return () => mql.removeEventListener('change', onChange)
   }, [])
 
-  return !!isMobile
+  return isMobile
 }

--- a/frontend/hooks/use-mobile.ts
+++ b/frontend/hooks/use-mobile.ts
@@ -1,24 +1,19 @@
-import { useEffect, useState } from 'react'
+import * as React from 'react'
 
 const MOBILE_BREAKPOINT = 768
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = useState<boolean>(() => {
-    return typeof window !== 'undefined'
-      ? window.innerWidth < MOBILE_BREAKPOINT
-      : false
-  })
+  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
 
-  useEffect(() => {
+  React.useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-
     const onChange = () => {
       setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
     }
-
     mql.addEventListener('change', onChange)
+    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
     return () => mql.removeEventListener('change', onChange)
   }, [])
 
-  return isMobile
+  return !!isMobile
 }


### PR DESCRIPTION
## Description

This PR addresses two linting errors that are currently causing CI failures:

- **react-hooks/refs**  
  Avoids accessing `ref.current` during the render phase in `tab-recorder.tsx`.

- **react-hooks/set-state-in-effect**  
  Refactors the mobile breakpoint check in `use-mobile.ts` to prevent synchronous `setState` calls within `useEffect`.

These issues are present in the current development branch and are blocking CI for other active feature branches (including the Guardrails PR). Merging this fix will unblock the pipeline and restore CI stability.