### PR TITLE
 fix(ci): Address minor bug  within ecs_task_start_failure's filter pattern (AIILG-297)

### DIFF
--- a/terraform/modules/monitoring/metrics.tf
+++ b/terraform/modules/monitoring/metrics.tf
@@ -200,8 +200,8 @@ resource "aws_cloudwatch_log_metric_filter" "ecs_task_start_failure" {
   name           = "ecs-task-start-failure-${each.value}-${var.environment_name}"
   pattern        = <<EOT
     {($.detail.stopCode = "TaskFailedToStart") &&
-     ($.detail-type = "ECS Task State Change")} &&
-     ($.detail.group = "service:${each.value}")
+     ($.detail-type = "ECS Task State Change") &&
+     ($.detail.group = "service:${each.value}")}
   EOT
 
   metric_transformation {


### PR DESCRIPTION
# Overview
The closing brace within ecs_task_start_failure's filter heredoc was misaligned which broke deployment. Refactored to fully capture all filter conditions within.