### PR TITLE
feat(terraform): APIM Cloudwatch alarm (AIILG-507)

### DIFF
--- a/common/llm/adapters/azure_apim.py
+++ b/common/llm/adapters/azure_apim.py
@@ -281,7 +281,6 @@ class AzureAPIMModelAdapter(ModelAdapter):
                 ("APIM WARNING: max output tokens reached " "(response_id=%s)"),
                 response.id,
             )
-
             return True
 
         return False

--- a/common/llm/adapters/azure_apim.py
+++ b/common/llm/adapters/azure_apim.py
@@ -69,10 +69,10 @@ class AzureAPIMModelAdapter(ModelAdapter):
         )
         parsed = response.choices[0].message.parsed
         if parsed is None:
-            msg = "Azure APIM response.parsed is None"
+            msg = "APIM ERROR: Azure APIM response.parsed is None"
             raise ValueError(msg)
         if not isinstance(parsed, response_format):
-            msg = f"Azure APIM parsed response is not of type {response_format}"
+            msg = f"APIM ERROR: Azure APIM parsed response is not of type {response_format}"
             raise TypeError(msg)
         return parsed
 
@@ -97,10 +97,10 @@ class AzureAPIMModelAdapter(ModelAdapter):
         self.choice_incomplete(choice, response)
         message_content = choice.message.content
         if message_content is None:
-            msg = "Azure APIM message.content is None"
+            msg = "APIM ERROR: Azure APIM message.content is None"
             raise ValueError(msg)
         if not isinstance(message_content, str):
-            msg = f"Azure APIM message.content is not a string: {type(message_content)}"
+            msg = f"APIM ERROR: Azure APIM message.content is not a string: {type(message_content)}"
             raise TypeError(msg)
         return message_content
 
@@ -126,7 +126,8 @@ class AzureAPIMModelAdapter(ModelAdapter):
                 await asyncio.sleep(wait_time)
             except AuthenticationError:
                 logger.warning(
-                    "%s - authentication error, refreshing token and retrying (attempt %d/%d)",
+                    "%s,%s - authentication error, refreshing token and retrying (attempt %d/%d)",
+                    "APIM ERROR: ",
                     method_name,
                     attempt + 1,
                     MAX_RETRIES,
@@ -136,7 +137,7 @@ class AzureAPIMModelAdapter(ModelAdapter):
                 if attempt == MAX_RETRIES - 1:
                     raise
             except (APIConnectionError, APIError) as e:
-                logger.error("%s - %s: %s", method_name, type(e).__name__, str(e))
+                logger.error("%s %s - %s: %s","APIM ERROR:", method_name, type(e).__name__, str(e))
                 raise
         msg = f"{method_name} - max retries exhausted"
         raise RuntimeError(msg)

--- a/common/llm/adapters/azure_apim.py
+++ b/common/llm/adapters/azure_apim.py
@@ -39,23 +39,34 @@ class AzureAPIMModelAdapter(ModelAdapter):
         self._cached_async_apim_client: AsyncOpenAI | None = None
 
     async def _get_apim_client(self) -> AsyncOpenAI:
+        logger.info("APIM CLIENT: retrieving APIM client token")
+
         token = await self._token_provider.get_token()
+
         if self._cached_async_apim_client is None or self._cached_async_apim_client.api_key != token:
+            logger.info("APIM CLIENT: creating new AsyncOpenAI client")
+
             self._cached_async_apim_client = AsyncOpenAI(
-                base_url=self._url + self._model,  # APIM URL expects model here
+                base_url=self._url + self._model,
                 api_key=token,
                 default_headers={
                     "Ocp-Apim-Subscription-Key": self._subscription_key,
                 },
                 max_retries=0,
             )
+
         return self._cached_async_apim_client
 
-    async def structured_chat[T](self, messages: list[dict[str, str]], response_format: type[T]) -> T:
+    async def structured_chat[T](
+        self,
+        messages: list[dict[str, str]],
+        response_format: type[T],
+    ) -> T:
         openai_messages = [convert_to_openai_message(msg) for msg in messages]
 
         async def call() -> ParsedChatCompletion[T]:
             client = await self._get_apim_client()
+
             return await client.beta.chat.completions.parse(
                 model=self._model,
                 messages=openai_messages,
@@ -63,24 +74,48 @@ class AzureAPIMModelAdapter(ModelAdapter):
                 extra_query={"api-version": self._api_version},
             )
 
+        logger.info("APIM REQUEST: structured_chat")
+
         response = await self._call_with_retry(
             call,
             "structured_chat",
         )
+
         parsed = response.choices[0].message.parsed
+
         if parsed is None:
-            msg = "APIM ERROR: Azure APIM response.parsed is None"
-            raise ValueError(msg)
+            error_msg = "Azure APIM response.parsed is None"
+
+            logger.error(
+                "APIM FAILURE: structured_chat - %s",
+                error_msg,
+            )
+
+            raise ValueError(error_msg)
+
         if not isinstance(parsed, response_format):
-            msg = f"APIM ERROR: Azure APIM parsed response is not of type {response_format}"
-            raise TypeError(msg)
+            error_msg = "Azure APIM parsed response is not of type " f"{response_format}"
+
+            logger.error(
+                "APIM FAILURE: structured_chat - %s",
+                error_msg,
+            )
+
+            raise TypeError(error_msg)
+
+        logger.info("APIM SUCCESS: structured_chat")
+
         return parsed
 
-    async def chat(self, messages: list[dict[str, str]]) -> str:
+    async def chat(
+        self,
+        messages: list[dict[str, str]],
+    ) -> str:
         openai_messages = [convert_to_openai_message(msg) for msg in messages]
 
         async def call() -> ChatCompletion:
             client = await self._get_apim_client()
+
             return await client.chat.completions.create(
                 model=self._model,
                 messages=openai_messages,
@@ -89,79 +124,164 @@ class AzureAPIMModelAdapter(ModelAdapter):
                 extra_query={"api-version": self._api_version},
             )
 
+        logger.info("APIM REQUEST: chat")
+
         response = await self._call_with_retry(
             call,
             "chat",
         )
+
         choice = response.choices[0]
+
         self.choice_incomplete(choice, response)
+
         message_content = choice.message.content
+
         if message_content is None:
-            msg = "APIM ERROR: Azure APIM message.content is None"
-            raise ValueError(msg)
+            error_msg = "Azure APIM message.content is None"
+
+            logger.error(
+                "APIM FAILURE: chat - %s",
+                error_msg,
+            )
+
+            raise ValueError(error_msg)
+
         if not isinstance(message_content, str):
-            msg = f"APIM ERROR: Azure APIM message.content is not a string: {type(message_content)}"
-            raise TypeError(msg)
+            error_msg = "Azure APIM message.content is not a string: " f"{type(message_content)}"
+
+            logger.error(
+                "APIM FAILURE: chat - %s",
+                error_msg,
+            )
+
+            raise TypeError(error_msg)
+
+        logger.info("APIM SUCCESS: chat")
+
         return message_content
 
     async def _call_with_retry[T_Response](
-        self, api_call: Callable[[], Awaitable[T_Response]], method_name: str
+        self,
+        api_call: Callable[[], Awaitable[T_Response]],
+        method_name: str,
     ) -> T_Response:
         for attempt in range(MAX_RETRIES):
             try:
-                response = await api_call()
-                logger.info("%s - request successful", method_name)
-                return response
-            except RateLimitError as e:
-                wait_time = self._extract_retry_after(e)
+                return await api_call()
+
+            except RateLimitError as error:
+                wait_time = self._extract_retry_after(error)
+
                 logger.warning(
-                    "%s - rate limit hit (attempt %d/%d), waiting %ds",
+                    ("APIM RETRY: %s - rate limit hit " "(attempt %d/%d), retrying in %ds"),
                     method_name,
                     attempt + 1,
                     MAX_RETRIES,
                     wait_time,
                 )
+
                 if attempt == MAX_RETRIES - 1:
+                    logger.error(
+                        "APIM FAILURE: %s - max retries exceeded due to rate limiting",
+                        method_name,
+                    )
                     raise
+
                 await asyncio.sleep(wait_time)
+
             except AuthenticationError:
                 logger.warning(
-                    "%s,%s - authentication error, refreshing token and retrying (attempt %d/%d)",
-                    "APIM ERROR: ",
+                    ("APIM RETRY: %s - authentication error, " "refreshing token and retrying " "(attempt %d/%d)"),
                     method_name,
                     attempt + 1,
                     MAX_RETRIES,
                 )
+
                 await self._token_provider.invalidate_token()
+
                 self._cached_async_apim_client = await self._get_apim_client()
+
                 if attempt == MAX_RETRIES - 1:
+                    logger.error(
+                        ("APIM FAILURE: %s - max retries exceeded " "due to authentication errors"),
+                        method_name,
+                    )
                     raise
-            except (APIConnectionError, APIError) as e:
-                logger.error("%s %s - %s: %s","APIM ERROR:", method_name, type(e).__name__, str(e))
+
+            except (APIConnectionError, APIError) as error:
+                logger.warning(
+                    ("APIM RETRY: %s - %s: %s " "(attempt %d/%d)"),
+                    method_name,
+                    type(error).__name__,
+                    str(error),
+                    attempt + 1,
+                    MAX_RETRIES,
+                )
+
+                if attempt == MAX_RETRIES - 1:
+                    logger.error(
+                        ("APIM FAILURE: %s - %s after maximum retries: %s"),
+                        method_name,
+                        type(error).__name__,
+                        str(error),
+                    )
+
                 raise
-        msg = f"{method_name} - max retries exhausted"
-        raise RuntimeError(msg)
+
+        error_msg = f"{method_name} - maximum retries exhausted"
+
+        logger.error(
+            "APIM FAILURE: %s",
+            error_msg,
+        )
+
+        raise RuntimeError(error_msg)
 
     @staticmethod
     def _extract_retry_after(error: RateLimitError) -> int:
-        retry_after_header = getattr(error.response, "headers", {}).get("Retry-After")
+        retry_after_header = getattr(
+            error.response,
+            "headers",
+            {},
+        ).get("Retry-After")
+
         if retry_after_header:
             try:
                 return int(retry_after_header)
+
             except ValueError:
-                logger.warning("Could not parse Retry-After header: %s", retry_after_header)
+                logger.warning(
+                    ("APIM WARNING: failed to parse " "Retry-After header: %s"),
+                    retry_after_header,
+                )
 
         error_message = str(error)
-        match = re.search(r"(?:Please )?retry after (\d+) second", error_message, re.IGNORECASE)
+
+        match = re.search(
+            r"(?:Please )?retry after (\d+) second",
+            error_message,
+            re.IGNORECASE,
+        )
+
         if match:
             return int(match.group(1))
 
-        logger.warning("Could not extract retry-after from error, using default 60 seconds")
+        logger.warning("APIM WARNING: could not determine retry-after " "value, defaulting to 60 seconds")
+
         return 60
 
     @staticmethod
-    def choice_incomplete(choice: Choice, response: ChatCompletion) -> bool:
+    def choice_incomplete(
+        choice: Choice,
+        response: ChatCompletion,
+    ) -> bool:
         if choice.finish_reason == "length":
-            logger.warning("max output tokens reached (response_id=%s)", response.id)
+            logger.warning(
+                ("APIM WARNING: max output tokens reached " "(response_id=%s)"),
+                response.id,
+            )
+
             return True
+
         return False

--- a/common/llm/adapters/azure_apim.py
+++ b/common/llm/adapters/azure_apim.py
@@ -8,6 +8,7 @@ from collections.abc import Awaitable, Callable
 from openai import (
     APIConnectionError,
     APIError,
+    APITimeoutError,
     AsyncOpenAI,
     AuthenticationError,
     RateLimitError,
@@ -215,7 +216,7 @@ class AzureAPIMModelAdapter(ModelAdapter):
                     )
                     raise
 
-            except (APIConnectionError, APIError) as error:
+            except (APIConnectionError, APIError, APITimeoutError) as error:
                 logger.warning(
                     ("APIM RETRY: %s - %s: %s " "(attempt %d/%d)"),
                     method_name,

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -253,4 +253,7 @@ module "monitoring" {
   waf_acl_name                        = module.frontdoor.waf_acl_name
   llm_deadletter_queue_name           = module.sqs.llm_deadletter_queue_name
   transcription_deadletter_queue_name = module.sqs.transcription_deadletter_queue_name
+  backend_log_group_name              = module.ecs.worker_log_group_name
+  worker_log_group_name               = module.ecs.worker_log_group_name
+
 }

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -256,7 +256,7 @@ module "monitoring" {
   waf_acl_name                        = module.frontdoor.waf_acl_name
   llm_deadletter_queue_name           = module.sqs.llm_deadletter_queue_name
   transcription_deadletter_queue_name = module.sqs.transcription_deadletter_queue_name
-  backend_log_group_name              = module.ecs.worker_log_group_name
+  backend_log_group_name              = module.ecs.backend_log_group_name
   worker_log_group_name               = module.ecs.worker_log_group_name
 
 }

--- a/terraform/modules/ecs/outputs.tf
+++ b/terraform/modules/ecs/outputs.tf
@@ -72,3 +72,13 @@ output "worker_service_name" {
   description = "The name of the worker ecs service"
   value       = aws_ecs_service.worker.name
 }
+
+output "backend_log_group_name" {
+  description = "CloudWatch log group name for backend ECS service logs"
+  value       = module.backend_log_group.name
+}
+
+output "worker_log_group_name" {
+  description = "CloudWatch log group name for worker ECS service logs"
+  value       = module.worker_log_group.name
+}

--- a/terraform/modules/monitoring/metrics.tf
+++ b/terraform/modules/monitoring/metrics.tf
@@ -210,3 +210,19 @@ resource "aws_cloudwatch_log_metric_filter" "ecs_task_start_failure" {
     value     = "1"
   }
 }
+
+resource "aws_cloudwatch_log_metric_filter" "apim_error_messages" {
+  for_each = toset(var.ecs_service_names)
+  log_group_name = module.backend_log_group.name
+  name =  "apim-error-logs-${var.environment_name}-${each.value}"
+  pattern =  <<EOT
+    "APIM ERROR:"
+  EOT
+
+  metric_transformation {
+    name = "placeholder"
+    namespace = "LogMetrics"
+    value = 1
+  }
+
+}

--- a/terraform/modules/monitoring/metrics.tf
+++ b/terraform/modules/monitoring/metrics.tf
@@ -211,18 +211,69 @@ resource "aws_cloudwatch_log_metric_filter" "ecs_task_start_failure" {
   }
 }
 
-resource "aws_cloudwatch_log_metric_filter" "apim_error_messages" {
-  for_each = toset(var.ecs_service_names)
-  log_group_name = module.backend_log_group.name
-  name =  "apim-error-logs-${var.environment_name}-${each.value}"
-  pattern =  <<EOT
-    "APIM ERROR:"
+
+resource "aws_cloudwatch_log_metric_filter" "apim_requests_backend" {
+  log_group_name = var.backend_log_group_name
+
+  name = "apim-requests-${var.environment_name}-backend"
+
+  pattern = <<EOT
+    "APIM REQUEST:"
   EOT
 
   metric_transformation {
-    name = "placeholder"
+    name      = "apim-requests-${var.environment_name}-backend"
     namespace = "LogMetrics"
-    value = 1
+    value     = "1"
   }
+}
 
+
+resource "aws_cloudwatch_log_metric_filter" "apim_failures_backend" {
+  log_group_name = var.backend_log_group_name
+
+  name = "apim-failures-${var.environment_name}-backend"
+
+  pattern = <<EOT
+    "APIM FAILURE:"
+  EOT
+
+  metric_transformation {
+    name      = "apim-failures-${var.environment_name}-backend"
+    namespace = "LogMetrics"
+    value     = "1"
+  }
+}
+
+
+resource "aws_cloudwatch_log_metric_filter" "apim_requests_worker" {
+  log_group_name = var.worker_log_group_name
+
+  name = "apim-requests-${var.environment_name}-worker"
+
+  pattern = <<EOT
+    "APIM REQUEST:"
+  EOT
+
+  metric_transformation {
+    name      = "apim-requests-${var.environment_name}-worker"
+    namespace = "LogMetrics"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "apim_failures_worker" {
+  log_group_name = var.worker_log_group_name
+
+  name = "apim-failures-worker-${var.environment_name}"
+
+  pattern = <<EOT
+    "APIM FAILURE:"
+  EOT
+
+  metric_transformation {
+    name      = "apim-failures-${var.environment_name}-worker"
+    namespace = "LogMetrics"
+    value     = "1"
+  }
 }

--- a/terraform/modules/monitoring/metrics.tf
+++ b/terraform/modules/monitoring/metrics.tf
@@ -265,7 +265,7 @@ resource "aws_cloudwatch_log_metric_filter" "apim_requests_worker" {
 resource "aws_cloudwatch_log_metric_filter" "apim_failures_worker" {
   log_group_name = var.worker_log_group_name
 
-  name = "apim-failures-worker-${var.environment_name}"
+  name = "apim-failures-${var.environment_name}-worker"
 
   pattern = <<EOT
     "APIM FAILURE:"
@@ -277,3 +277,4 @@ resource "aws_cloudwatch_log_metric_filter" "apim_failures_worker" {
     value     = "1"
   }
 }
+

--- a/terraform/modules/monitoring/resource_alarms.tf
+++ b/terraform/modules/monitoring/resource_alarms.tf
@@ -189,3 +189,64 @@ resource "aws_cloudwatch_metric_alarm" "waf_blocked_requests" {
     aws_sns_topic.us_alarm_sns_topic.arn,
   ]
 }
+
+
+resource "aws_cloudwatch_metric_alarm" "apim_failure_rate" {
+  alarm_name          = "${var.environment_name}-apim-failure-rate"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  threshold           = 10
+  datapoints_to_alarm = 2
+  treat_missing_data  = "notBreaching"
+
+  metric_query {
+    id = "backend_requests"
+    metric {
+      namespace   = "LogMetrics"
+      metric_name = "apim-requests-${var.environment_name}-backend"
+      period      = 60
+      stat        = "Sum"
+    }
+  }
+
+  metric_query {
+    id = "backend_failures"
+    metric {
+      namespace   = "LogMetrics"
+      metric_name = "apim-failures-${var.environment_name}-backend"
+      period      = 60
+      stat        = "Sum"
+    }
+  }
+
+  metric_query {
+    id = "worker_requests"
+    metric {
+      namespace   = "LogMetrics"
+      metric_name = "apim-requests-${var.environment_name}-worker"
+      period      = 60
+      stat        = "Sum"
+    }
+  }
+
+  metric_query {
+    id = "worker_failures"
+    metric {
+      namespace   = "LogMetrics"
+      metric_name = "apim-failures-${var.environment_name}-worker"
+      period      = 60
+      stat        = "Sum"
+    }
+  }
+
+  metric_query {
+    id          = "rate"
+    expression  = "IF((backend_requests + worker_requests) > 0, ((backend_failures + worker_failures) / (backend_requests + worker_requests)) * 100, 0)"
+    label       = "APIM Failure Rate"
+    return_data = true
+  }
+
+  alarm_actions = [
+    aws_sns_topic.alarm_sns_topic.arn
+  ]
+}

--- a/terraform/modules/monitoring/variables.tf
+++ b/terraform/modules/monitoring/variables.tf
@@ -71,3 +71,15 @@ variable "llm_deadletter_queue_name" {
   description = "Name of the SQS queue for LLM processing, to create alarms for"
   type        = string
 }
+
+variable "worker_log_group_name" {
+  description = "CloudWatch log group name for worker ECS service logs"
+
+  type = string
+}
+
+variable "backend_log_group_name" {
+  description = "CloudWatch log group name for backend ECS service logs"
+
+  type = string
+}

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -256,6 +256,6 @@ module "monitoring" {
   waf_acl_name                        = module.frontdoor.waf_acl_name
   llm_deadletter_queue_name           = module.sqs.llm_deadletter_queue_name
   transcription_deadletter_queue_name = module.sqs.transcription_deadletter_queue_name
-  backend_log_group_name              = module.ecs.worker_log_group_name
+  backend_log_group_name              = module.ecs.backend_log_group_name
   worker_log_group_name               = module.ecs.worker_log_group_name
 }

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -253,4 +253,6 @@ module "monitoring" {
   waf_acl_name                        = module.frontdoor.waf_acl_name
   llm_deadletter_queue_name           = module.sqs.llm_deadletter_queue_name
   transcription_deadletter_queue_name = module.sqs.transcription_deadletter_queue_name
+  backend_log_group_name              = module.ecs.worker_log_group_name
+  worker_log_group_name               = module.ecs.worker_log_group_name
 }


### PR DESCRIPTION
# Overview
Create Cloudwatch alarms to accurate gauge APIM failure rates

## JIRA Ticket507
https://mhclgdigital.atlassian.net/browse/AIILG-507

## Changes
- To accurately measure the rate in which APIM requests fail, the source code was amended to emit specific log keywords that can be captured by Cloudwatch metric filters. Only two keywords are currently used for metrics (APIM REQUEST and APIM FAILURE), while additional logs (APIM RETRY, APIM CLIENT and APIM WARNING) were included for consistency and potential future use.
- Metrics were created to capture request and failure counts across both backend and worker services.
- An error rate alarm was created which combines the four metrics (backend requests, backend failures, worker requests, worker failures) and evaluates the overall APIM failure rate against a 10% threshold. The alarm is configured to trigger when the threshold is breached in 2 out of 3 evaluation periods. Thresholds and evaluation periods will be adjusted as we gain a better understanding of acceptable failure rates.



