### PR TITLE
qol(terraform): Testing hidding non-changes

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -64,11 +64,18 @@ jobs:
             const issue_number = context.payload.pull_request.number;
             const sha = context.sha;
 
-            // Returns true only if every changed resource is an ECS task definition or service.
-            // Any other resource type (RDS, ALB, etc.) means this is a real infra change.
+            // Returns true only if the plan has the exact shape of an image-tag bump:
+            // task definitions must be replaced (always true for an image change) and
+            // services must be updated in-place (they just re-point to the new task def).
+            // Any other action type (a service being replaced, a task def updated in-place)
+            // or any non-ECS resource means this is a real infra change.
             const onlyEcsResources = (planText) => {
-              const changed = [...planText.matchAll(/# \S+ (will be updated in-place|must be replaced)/g)];
-              return changed.length > 0 && changed.every(m => /aws_ecs_(task_definition|service)/.test(m[0]));
+              const allChanged = [...planText.matchAll(/# \S+ (will be updated in-place|must be replaced)/g)];
+              if (allChanged.length === 0) return false;
+              const taskDefReplacements = [...planText.matchAll(/# \S+aws_ecs_task_definition\.\S+ must be replaced/g)];
+              const serviceUpdates = [...planText.matchAll(/# \S+aws_ecs_service\.\S+ will be updated in-place/g)];
+              return taskDefReplacements.length > 0
+                && (taskDefReplacements.length + serviceUpdates.length) === allChanged.length;
             };
 
             // Returns true only if every modified (~) field is a known metadata side-effect of

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -62,6 +62,37 @@ jobs:
             const header = '## Terraform Plan';
             const { owner, repo } = context.repo;
             const issue_number = context.payload.pull_request.number;
+            const sha = context.sha;
+
+            const isImageOnlyBump = (() => {
+              const resourceMatches = [...plan.matchAll(/# \S+ (will be updated in-place|must be replaced)/g)];
+              if (resourceMatches.length === 0) return false;
+              if (!resourceMatches.every(m => /aws_ecs_(task_definition|service)/.test(m[0]))) return false;
+              const allowedFields = /^~\s+(image|arn|arn_without_revision|id|revision|tags_all|enable_fault_injection|task_definition|container_definitions)\s+=/;
+              const changedLines = plan.split('\n').filter(l => /^\s+~\s+\w+\s+=/.test(l));
+              if (!changedLines.every(l => allowedFields.test(l.trim()))) return false;
+              const addedFieldLines = plan.split('\n').filter(l => /^\s+\+\s+\w+\s+=/.test(l));
+              if (addedFieldLines.length > 0) return false;
+              return true;
+            })();
+
+            let body;
+            if (isImageOnlyBump) {
+              body = `${header}
+
+:white_check_mark: Image tag bump only — deploying commit \`${sha.slice(0, 7)}\` to all services. No infrastructure changes, no review needed.
+
+<details>
+<summary>Full plan</summary>
+
+\`\`\`
+${plan}
+\`\`\`
+
+</details>`;
+            } else {
+              body = `${header}\n\`\`\`\n${plan}\n\`\`\``;
+            }
 
             const { data: comments } = await github.rest.issues.listComments({
               owner,
@@ -76,13 +107,13 @@ jobs:
                 owner,
                 repo,
                 comment_id: existing.id,
-                body: `${header}\n\`\`\`\n${plan}\n\`\`\``,
+                body,
               });
             } else {
               await github.rest.issues.createComment({
                 owner,
                 repo,
                 issue_number,
-                body: `${header}\n\`\`\`\n${plan}\n\`\`\``,
+                body,
               });
             }

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -64,17 +64,29 @@ jobs:
             const issue_number = context.payload.pull_request.number;
             const sha = context.sha;
 
-            const isImageOnlyBump = (() => {
-              const resourceMatches = [...plan.matchAll(/# \S+ (will be updated in-place|must be replaced)/g)];
-              if (resourceMatches.length === 0) return false;
-              if (!resourceMatches.every(m => /aws_ecs_(task_definition|service)/.test(m[0]))) return false;
+            // Returns true only if every changed resource is an ECS task definition or service.
+            // Any other resource type (RDS, ALB, etc.) means this is a real infra change.
+            const onlyEcsResources = (planText) => {
+              const changed = [...planText.matchAll(/# \S+ (will be updated in-place|must be replaced)/g)];
+              return changed.length > 0 && changed.every(m => /aws_ecs_(task_definition|service)/.test(m[0]));
+            };
+
+            // Returns true only if every modified (~) field is a known metadata side-effect of
+            // a task definition replacement (arn, revision, etc.) or the image field itself.
+            // Fields like cpu, memory, environment, health_check would fail this check.
+            const onlyAllowedFieldChanges = (planText) => {
               const allowedFields = /^~\s+(image|arn|arn_without_revision|id|revision|tags_all|enable_fault_injection|task_definition|container_definitions)\s+=/;
-              const changedLines = plan.split('\n').filter(l => /^\s+~\s+\w+\s+=/.test(l));
-              if (!changedLines.every(l => allowedFields.test(l.trim()))) return false;
-              const addedFieldLines = plan.split('\n').filter(l => /^\s+\+\s+\w+\s+=/.test(l));
-              if (addedFieldLines.length > 0) return false;
-              return true;
-            })();
+              const changedLines = planText.split('\n').filter(l => /^\s+~\s+\w+\s+=/.test(l));
+              return changedLines.every(l => allowedFields.test(l.trim()));
+            };
+
+            // Returns true only if no new fields are being added (+).
+            // A new sidecar container, for example, appears entirely as + lines and would
+            // otherwise slip past the ~ check above.
+            const noNewFields = (planText) =>
+              !planText.split('\n').some(l => /^\s+\+\s+\w+\s+=/.test(l));
+
+            const isImageOnlyBump = onlyEcsResources(plan) && onlyAllowedFieldChanges(plan) && noNewFields(plan);
 
             let body;
             if (isImageOnlyBump) {

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -53,10 +53,10 @@ jobs:
           path: terraform/development/tf_plan.txt
 
       - name: Publish plan to PR
-        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |
+            if (!context.payload.pull_request) return;
             const fs = require('fs');
             const plan = fs.readFileSync('terraform/development/tf_plan.txt', 'utf8');
             const header = '## Terraform Plan';
@@ -97,18 +97,20 @@ jobs:
 
             let body;
             if (isImageOnlyBump) {
-              body = `${header}
-
-:white_check_mark: Image tag bump only — deploying commit \`${sha.slice(0, 7)}\` to all services. No infrastructure changes, no review needed.
-
-<details>
-<summary>Full plan</summary>
-
-\`\`\`
-${plan}
-\`\`\`
-
-</details>`;
+              body = [
+                header,
+                '',
+                `:white_check_mark: Image tag bump only — deploying commit \`${sha.slice(0, 7)}\` to all services. No infrastructure changes, no review needed.`,
+                '',
+                '<details>',
+                '<summary>Full plan</summary>',
+                '',
+                '```',
+                plan,
+                '```',
+                '',
+                '</details>',
+              ].join('\n');
             } else {
               body = `${header}\n\`\`\`\n${plan}\n\`\`\``;
             }

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -178,7 +178,7 @@ module "ecs" {
   source = "../modules/ecs"
 
   environment_name            = local.environment_name
-  frontend_task_desired_count = 2
+  frontend_task_desired_count = 1
   backend_task_desired_count  = 1
   worker_task_desired_count   = 1
   frontend_port               = local.frontend_port

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -178,7 +178,7 @@ module "ecs" {
   source = "../modules/ecs"
 
   environment_name            = local.environment_name
-  frontend_task_desired_count = 1
+  frontend_task_desired_count = 2
   backend_task_desired_count  = 1
   worker_task_desired_count   = 1
   frontend_port               = local.frontend_port


### PR DESCRIPTION
# Overview
Routine deploys were generating full Terraform plan comments on every PR, causing alert overload. The CI now detects image-tag-only bumps and replaces the wall of plan output with a one-line summary, keeping the full plan collapsed for reference.

## JIRA Ticket
No JIRA

## Changes

- Image-tag-only plans post a short summary comment instead of the raw plan dump
- Full plan remains available in a collapsed `<details>` block
- Detection uses three guards: ECS-only resources, no unexpected field changes, no new field additions (e.g. new sidecar containers)

## Acceptance Criteria (AC)

- [ ] Image-tag-only plan → short summary comment with collapsed full plan
- [ ] Any real infra change → full plan comment as before

---

## Testing (if applicable)

- **Manual**: Push to a PR and verify the comment format matches the plan type, then push a modifing change and verify the plan is shown in full.

## Notes / Additional Information (optional)

If a new AWS provider version introduces additional metadata fields in image-only plans, add them to the `allowedFields` allowlist in `terraform-plan.yml`.