### PR TITLE
fix(backend): Clean up audio tests (AIILG-561)

### DIFF
--- a/tests/common/audio/test_ffmpeg.py
+++ b/tests/common/audio/test_ffmpeg.py
@@ -40,4 +40,3 @@ def test_convert_to_mp3(filename: Path):
 
     result.unlink()
     assert not result.exists()
-

--- a/tests/common/audio/test_ffmpeg.py
+++ b/tests/common/audio/test_ffmpeg.py
@@ -3,38 +3,43 @@ from pathlib import Path
 import pytest
 
 from common.audio.ffmpeg import convert_to_mp3, get_duration, get_num_audio_channels
-from tests.marks import requires_audio_data
 from tests.utils import FileTypeTests
 
-pytestmark = [requires_audio_data]
 
-
-def get_normal_data():
-    return list(Path(".data").joinpath("test_audio").joinpath(FileTypeTests.NORMAL).iterdir())
+def _has_audio_data() -> bool:
+    path = Path(".data") / "test_audio" / FileTypeTests.NORMAL
+    return path.exists() and any(path.iterdir())
 
 
 @pytest.fixture
-def filename(request):
-    return request.param
+def audio_files():
+    path = Path(".data") / "test_audio" / FileTypeTests.NORMAL
+
+    if not _has_audio_data():
+        pytest.skip(f"Missing test audio data at {path}")
+
+    return list(path.iterdir())
 
 
-@pytest.mark.parametrize("filename", get_normal_data(), indirect=True)
-def test_get_duration(filename: Path):
-    result = get_duration(filename)
-    assert result > 0
+def test_get_duration(audio_files):
+    for filename in audio_files:
+        result = get_duration(filename)
+        assert result > 0
 
 
-@pytest.mark.parametrize("filename", get_normal_data(), indirect=True)
-def test_get_num_audio_channels(filename: Path):
-    result = get_num_audio_channels(filename)
-    assert result > -1
+def test_get_num_audio_channels(audio_files):
+    for filename in audio_files:
+        result = get_num_audio_channels(filename)
+        assert result > -1
 
 
-@pytest.mark.parametrize("filename", get_normal_data(), indirect=True)
-def test_convert_to_mp3(filename: Path):
-    result = Path(convert_to_mp3(filename))
-    assert result.suffix == ".mp3"
-    assert result.exists()
-    assert result.stat().st_size > 0
-    result.unlink()
-    assert not result.exists()
+def test_convert_to_mp3(audio_files):
+    for filename in audio_files:
+        result = Path(convert_to_mp3(filename))
+
+        assert result.suffix == ".mp3"
+        assert result.exists()
+        assert result.stat().st_size > 0
+
+        result.unlink()
+        assert not result.exists()

--- a/tests/common/audio/test_ffmpeg.py
+++ b/tests/common/audio/test_ffmpeg.py
@@ -6,40 +6,38 @@ from common.audio.ffmpeg import convert_to_mp3, get_duration, get_num_audio_chan
 from tests.utils import FileTypeTests
 
 
-def _has_audio_data() -> bool:
-    path = Path(".data") / "test_audio" / FileTypeTests.NORMAL
-    return path.exists() and any(path.iterdir())
-
-
-@pytest.fixture
-def audio_files():
+def get_normal_data() -> list[Path]:
     path = Path(".data") / "test_audio" / FileTypeTests.NORMAL
 
-    if not _has_audio_data():
-        pytest.skip(f"Missing test audio data at {path}")
+    if not path.exists() or not any(path.iterdir()):
+        pytest.skip(
+            f"Missing test audio data at {path}",
+            allow_module_level=True,
+        )
 
     return list(path.iterdir())
 
 
-def test_get_duration(audio_files):
-    for filename in audio_files:
-        result = get_duration(filename)
-        assert result > 0
+@pytest.mark.parametrize("filename", get_normal_data())
+def test_get_duration(filename: Path):
+    result = get_duration(filename)
+    assert result > 0
 
 
-def test_get_num_audio_channels(audio_files):
-    for filename in audio_files:
-        result = get_num_audio_channels(filename)
-        assert result > -1
+@pytest.mark.parametrize("filename", get_normal_data())
+def test_get_num_audio_channels(filename: Path):
+    result = get_num_audio_channels(filename)
+    assert result > -1
 
 
-def test_convert_to_mp3(audio_files):
-    for filename in audio_files:
-        result = Path(convert_to_mp3(filename))
+@pytest.mark.parametrize("filename", get_normal_data())
+def test_convert_to_mp3(filename: Path):
+    result = Path(convert_to_mp3(filename))
 
-        assert result.suffix == ".mp3"
-        assert result.exists()
-        assert result.stat().st_size > 0
+    assert result.suffix == ".mp3"
+    assert result.exists()
+    assert result.stat().st_size > 0
 
-        result.unlink()
-        assert not result.exists()
+    result.unlink()
+    assert not result.exists()
+

--- a/tests/common/services/queue_services/test_queues_e2e.py
+++ b/tests/common/services/queue_services/test_queues_e2e.py
@@ -22,7 +22,7 @@ from common.types import (
     RecordingCreateRequest,
     TranscriptionCreateRequest,
 )
-from tests.marks import costs_money
+from tests.marks import costs_money, requires_audio_data
 from tests.utils import FileTypeTests, get_test_client
 from worker.worker_service import WorkerService, create_worker_service
 
@@ -81,7 +81,7 @@ async def load_db_test_instance(file_type: FileTypeTests) -> set[UUID]:
     return test_ids
 
 
-@pytest.mark.requires_audio_data
+@requires_audio_data
 @pytest.mark.asyncio(loop_scope="session")
 async def test_e2e(worker_service):
     worker_service_task = asyncio.create_task(worker_service.run())
@@ -97,7 +97,7 @@ async def test_e2e(worker_service):
     worker_service_task.cancel()
 
 
-@pytest.mark.requires_audio_data
+@requires_audio_data
 @pytest.mark.asyncio(loop_scope="session")
 async def test_e2e_chat(worker_service):
     worker_service_task = asyncio.create_task(worker_service.run())
@@ -118,7 +118,7 @@ async def test_e2e_chat(worker_service):
     worker_service_task.cancel()
 
 
-@pytest.mark.requires_audio_data
+@requires_audio_data
 @pytest.mark.asyncio(loop_scope="session")
 async def test_e2e_zero_bytes(worker_service):
     worker_service_task = asyncio.create_task(worker_service.run())
@@ -130,7 +130,7 @@ async def test_e2e_zero_bytes(worker_service):
     worker_service_task.cancel()
 
 
-@pytest.mark.requires_audio_data
+@requires_audio_data
 @pytest.mark.asyncio(loop_scope="session")
 async def test_e2e_corrupted(worker_service):
     worker_service_task = asyncio.create_task(worker_service.run())


### PR DESCRIPTION
# Overview
Audio tests were previously unstable due to filesystem checks happening at collection time, causing failures when test data wasn’t present (the default case . Incorrect pytest marker usage in test_queues also led to misleading skip/failure behaviour.

Refactored to runtime-based fixtures and corrected marker usage, ensuring tests now skip cleanly and behave consistently.

## JIRA Ticket
https://mhclgdigital.atlassian.net/browse/AIILG-561

## Changes

- Updated audio test skip behaviour to cleanly skip when test data is unavailable
- Corrected pytest marker usage from pytest.mark.requires_audio_data to @requires_audio_data
- Removed redundant indirect parametrization and simplified audio test structure

