### PR TITLE
feat(ci): Manual deployment for the staging environment (AIILG-550)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,11 +5,32 @@ on:
     branches:
       - development
 
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Deployment environment"
+        required: true
+        type: choice
+        options:
+          - staging
+
 jobs:
   deploy-development:
+    if: github.event_name == 'push'
     uses: ./.github/workflows/deploy-base.yml
     with:
       environment: development
     secrets:
       aws-account-id: ${{ secrets.DEV_AWS_ACCOUNT_ID }}
       alarm-email-address: ${{ secrets.DEV_ALARM_EMAIL_ADDRESS }}
+  
+  deploy-staging:
+    if: github.event_name == 'workflow_dispatch' && inputs.environment == 'staging'
+    uses: ./.github/workflows/deploy-base.yml
+    with:
+      environment: ${{ inputs.environment }}
+    secrets:
+      aws-account-id: ${{ secrets.STAGING_AWS_ACCOUNT_ID }}
+      alarm-email-address: ${{ secrets.STAGING_ALARM_EMAIL_ADDRESS }}
+
+    


### PR DESCRIPTION
# Overview
Update workflows to allow for manual deployment to the staging environment

## JIRA Ticket
https://mhclgdigital.atlassian.net/browse/AIILG-550

## Changes
- Updated the deploy workflow to allow for a manual deployment within the env provided as options (only staging for now, others to be included in the future)


## Acceptance Criteria (AC)

- I can select the deploy action and manually trigger it for a given environment and commit/branch/tag

- When I run the deployment action against an environment, the code from that commit/branch/tag is built and pushed, and any terraform changes are deployed - including running those new images.

- If there are any errors in the steps before the terraform apply, the new terraform is not applied, i.e. the deployment is cancelled.

