### PR TITLE
fix: Address ALB errors with local setup (AIILG-575)

### DIFF
--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -6,8 +6,6 @@ import {
 } from './utils/auth'
 import { API_PROXY_PATH } from './lib/constants'
 
-const verifier = createAlbJwtVerifier()
-
 // Define paths that should be public (no authorisation required)
 const PUBLIC_PATHS = [
   '/unauthorised',
@@ -39,6 +37,8 @@ export async function proxy(req: NextRequest) {
     let authResult: UserAuthorisationResult | null = null
 
     if (process.env.ENVIRONMENT !== 'local') {
+      const verifier = createAlbJwtVerifier()
+
       const token = req.headers.get('x-amzn-oidc-data')
 
       if (!token) {

--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -6,6 +6,9 @@ import {
 } from './utils/auth'
 import { API_PROXY_PATH } from './lib/constants'
 
+const verifier =
+  process.env.ENVIRONMENT !== 'local' ? createAlbJwtVerifier() : null
+
 // Define paths that should be public (no authorisation required)
 const PUBLIC_PATHS = [
   '/unauthorised',
@@ -37,8 +40,6 @@ export async function proxy(req: NextRequest) {
     let authResult: UserAuthorisationResult | null = null
 
     if (process.env.ENVIRONMENT !== 'local') {
-      const verifier = createAlbJwtVerifier()
-
       const token = req.headers.get('x-amzn-oidc-data')
 
       if (!token) {
@@ -48,7 +49,9 @@ export async function proxy(req: NextRequest) {
         return redirectToUnauthorised(req)
       }
 
-      authResult = await parseAuthToken(verifier, token)
+      if (verifier) {
+        authResult = await parseAuthToken(verifier, token)
+      }
     } else {
       authResult = {
         email: 'test@test.co.uk',


### PR DESCRIPTION
# Overview
ALB env vars (createAlbJwtVerifier) were being instantiated before the runtime environment was determined. This caused local setup failures as those vars don’t exist outside the deployed AWS environment. Moving the call into a more appropriate scope resolves the issue.

## JIRA Ticket
https://mhclgdigital.atlassian.net/browse/AIILG-575



