### PR TITLE
bug(infra): Syntax error within workflow(AIILG-608)

### DIFF
--- a/.github/workflows/deploy-base.yml
+++ b/.github/workflows/deploy-base.yml
@@ -110,14 +110,14 @@ jobs:
         continue-on-error: true
 
       - name: Fail if plan errored
-        if: steps.plan.outputs.exitcode == "1"
+        if: ${{ steps.plan.outputs.exitcode == '1' }}
         run: exit 1
 
   apply:
     name: Terraform apply
     runs-on: ubuntu-latest
     needs: plan
-    if: needs.plan.outputs.exitcode == "2"
+    if: ${{ needs.plan.outputs.exitcode == '2' }}
     concurrency: tfstate-${{ inputs.environment }}
     defaults:
       run:


### PR DESCRIPTION
# Overview
Syntax error causing working to fail 

```
(Line: 113, Col: 13): Unexpected symbol: '"1"'. Located at position 32 within expression: steps.plan.outputs.exitcode == "1", (Line: 120, Col: 9): Unexpected symbol: '"2"'. Located at position 32 within expression: needs.plan.outputs.exitcode == "2"

```

## JIRA Ticket
https://mhclgdigital.atlassian.net/browse/AIILG-608

## Changes
- Wrapped conditional in an expression

