### PR TITLE
bug(infra): Investigate why the tf apply step skips (AIILG-624)

### DIFF
--- a/.github/workflows/deploy-base.yml
+++ b/.github/workflows/deploy-base.yml
@@ -101,24 +101,24 @@ jobs:
         id: plan
         env:
           TF_VAR_alarm_email_address: ${{ secrets.alarm-email-address }}
-        run: |
-          set +e
-          terraform plan -input=false -lock=false -detailed-exitcode -var="image_tag=${{ github.sha }}"
-          EXITCODE=$?
-          echo "exitcode=$EXITCODE" >> $GITHUB_OUTPUT
-          echo "Terraform plan output exitcode: $EXITCODE"
-          exit $EXITCODE
+
+        run: terraform plan -input=false -lock=false -detailed-exitcode -var="image_tag=${{ github.sha }}"
         continue-on-error: true
 
+      - name: Output plan exitcode
+        run: |
+          echo "=== PLAN EXITCODE ==="
+          echo "Terraform plan exitcode: ${{ steps.plan.outputs.exitcode }}"
+
       - name: Fail if plan errored
-        if:  steps.plan.outputs.exitcode == 1
+        if: steps.plan.outputs.exitcode == 1
         run: exit 1
 
   apply:
     name: Terraform apply
     runs-on: ubuntu-latest
     needs: plan
-    if:  needs.plan.outputs.exitcode == 2
+    if: needs.plan.outputs.exitcode == 2
     concurrency: tfstate-${{ inputs.environment }}
     defaults:
       run:


### PR DESCRIPTION
# Overview
The apply step of the deploy workflow would skip. This was due to a conflicting outputs between the  tf wrapper and a custom shell  used to execute the step. 

## JIRA Ticket
https://mhclgdigital.atlassian.net/browse/AIILG-624

## Changes
- Simplified  the workflow to solely use the wrapper's captured outputs

