### PR TITLE
fix(deps): fix poetry to 2.4.1 (AIILG-628)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
     uses: ./.github/workflows/backend-tests.yml
     with:
       python_version: "3.12"
-      poetry_version: "2.2.1"
+      poetry_version: "2.4.1"
     secrets: inherit
 
   frontend_tests:

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -4,7 +4,7 @@ name: type-check
 
 env:
   PYTHON_VERSION: "3.12"
-  POETRY_VERSION: "2.2.1"
+  POETRY_VERSION: "2.4.1"
 
 on:
   pull_request:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends build-essential=12.12 && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir poetry==2.2.1 poetry-plugin-export==1.9.0
+RUN pip install --no-cache-dir poetry==2.4.1 poetry-plugin-export==1.9.0
 WORKDIR /app
 COPY pyproject.toml poetry.lock README.md ./
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ packages = [
     {include = "backend"},
     {include = "common"},
 ]
-requires-poetry = "=2.2.1"
+requires-poetry = "=2.4.1"
 
 # add common dependencies here
 [tool.poetry.dependencies]

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
 WORKDIR /app
 
 # Install Poetry
-RUN pip install --no-cache-dir poetry==2.2.1 poetry-plugin-export==1.9.0
+RUN pip install --no-cache-dir poetry==2.4.1 poetry-plugin-export==1.9.0
 
 COPY pyproject.toml poetry.lock README.md ./
 


### PR DESCRIPTION
# Overview
Updates the pinned Poetry version from 2.2.1 to 2.4.1 across all CI workflows and Dockerfiles. The previous pin to 2.2.1 was causing Dependabot to fail — it reported incompatibility with Poetry 2.2.1 — and upgrading to 2.4.1 resolves this while staying on a stable, current release.

## JIRA Ticket
https://mhclgdigital.atlassian.net/browse/AIILG-628

## Changes

- Updated `poetry_version` in `.github/workflows/tests.yml` from `2.2.1` → `2.4.1`
- Updated `POETRY_VERSION` env var in `.github/workflows/type-check.yml` from `2.2.1` → `2.4.1`
- Updated `pip install poetry==` in `backend/Dockerfile` from `2.2.1` → `2.4.1`
- Updated `pip install poetry==` in `worker/Dockerfile` from `2.2.1` → `2.4.1`
- Updated `requires-poetry` constraint in `pyproject.toml` from `=2.2.1` → `=2.4.1`

## Acceptance Criteria (AC)

- [ ] AC1: Dependabot no longer reports a Poetry version incompatibility error
- [ ] AC2: CI tests workflow runs successfully with Poetry 2.4.1
- [ ] AC3: Type-check workflow runs successfully with Poetry 2.4.1
- [ ] AC4: Backend and worker Docker builds complete without errors
