### PR TITLE
feat(backend) - Domain name mismatch with signout (AIILG-629)

### DIFF
--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -22,7 +22,11 @@ async def sign_out(request: Request) -> RedirectResponse:
     """Sign out the user by clearing ALB auth cookies and redirecting to the IdP."""
 
     end_session_endpoint = await get_idp_logout_url() or END_SESSION_ENDPOINT_STATIC
-    domain = request.url.hostname
+
+    logger.info("host=%s", request.headers.get("host"))
+    logger.info("x-forwarded-host=%s", request.headers.get("x-forwarded-host"))
+    
+    domain = domain = request.headers.get("x-forwarded-host") or request.headers.get("host")
 
     response = RedirectResponse(
         url=end_session_endpoint,

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -25,8 +25,9 @@ async def sign_out(request: Request) -> RedirectResponse:
 
     logger.info("host=%s", request.headers.get("host"))
     logger.info("x-forwarded-host=%s", request.headers.get("x-forwarded-host"))
-    
-    domain = domain = request.headers.get("x-forwarded-host") or request.headers.get("host")
+    logger.info("all headers: %s", request.headers.keys())
+
+    domain = request.headers.get("x-forwarded-host") or request.headers.get("host")
 
     response = RedirectResponse(
         url=end_session_endpoint,


### PR DESCRIPTION
# Overview
The domain name when setting the expiry cookies was resolving with the alb's internal host name (local-transcribe-backend.local......internal) rather than the expected. My suspicion (&hope) is that the mismatch proves to be the final roadblock in resolving this PR. 

## JIRA Ticket
https://mhclgdigital.atlassian.net/browse/AIILG-629

## Changes

- Using the value from x-forwarded-host instead.
- Added some logs for debugging purposes (these will ofc be removed)


