### PR TITLE
chore: add pentester IPs to our IP allowlist (AIILG-652)

### DIFF
--- a/terraform/modules/frontdoor/cloudfront_waf.tf
+++ b/terraform/modules/frontdoor/cloudfront_waf.tf
@@ -22,7 +22,7 @@ resource "aws_wafv2_web_acl" "main" {
 
   dynamic "rule" {
     # [{}] causes 1 instance of the block to be created, [] causes 0 instances of the block
-    for_each = length(var.ip_allowlist) > 0 ? [{}] : []
+    for_each = length(var.ip_allowlist) + length(var.ipv6_allowlist) > 0 ? [{}] : []
     content {
       name     = "ip-allowlist"
       priority = 1
@@ -38,8 +38,17 @@ resource "aws_wafv2_web_acl" "main" {
       statement {
         not_statement {
           statement {
-            ip_set_reference_statement {
-              arn = aws_wafv2_ip_set.allowed_ips.arn
+            or_statement {
+              statement {
+                ip_set_reference_statement {
+                  arn = aws_wafv2_ip_set.allowed_ips.arn
+                }
+              }
+              statement {
+                ip_set_reference_statement {
+                  arn = aws_wafv2_ip_set.allowed_ipv6_ips.arn
+                }
+              }
             }
           }
         }
@@ -197,4 +206,13 @@ resource "aws_wafv2_ip_set" "allowed_ips" {
   scope              = "CLOUDFRONT"
   ip_address_version = "IPV4"
   addresses          = var.ip_allowlist
+}
+
+resource "aws_wafv2_ip_set" "allowed_ipv6_ips" {
+  provider = aws.us-east-1
+
+  name               = "waf-allowed-ipv6-ip-set-${var.environment_name}"
+  scope              = "CLOUDFRONT"
+  ip_address_version = "IPV6"
+  addresses          = var.ipv6_allowlist
 }

--- a/terraform/modules/frontdoor/variables.tf
+++ b/terraform/modules/frontdoor/variables.tf
@@ -58,7 +58,13 @@ variable "load_balancer_domain_name" {
 
 variable "ip_allowlist" {
   type        = list(string)
-  description = "List of allowed IPs - if empty then no ip restrictions are applied"
+  description = "List of allowed IPs - if both this and ipv6_allowlist are empty then no ip restrictions are applied"
+  default     = []
+}
+
+variable "ipv6_allowlist" {
+  type        = list(string)
+  description = "List of allowed IPv6 IPs - if both this and ip_allowlist are empty then no ip restrictions are applied"
   default     = []
 }
 

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -88,7 +88,16 @@ module "frontdoor" {
     "45.150.142.210/32",
     # MHCLG
     "4.158.35.41/32",
+    # Cyberfort (temporarily allowed for pen testing)
+    # TODO AIILG-653 remove these after pen testing is complete
+    "37.200.119.11",
+    "185.10.12.32/28",
+    "176.65.68.112/28",
   ]
+
+  # Cyberfort (temporarily allowed for pen testing)
+  # TODO AIILG-653 remove this after pen testing is complete
+  ipv6_allowlist = ["2a00:1430:2106::/48"]
 
   app_host                                = local.app_host
   internal_access_oidc_client_id_name     = module.secrets.internal_access_oidc_client_id_name


### PR DESCRIPTION
# Overview
Allow IPs used by our cyberfort pentesters to access our staging environment

## JIRA Ticket
https://mhclgdigital.atlassian.net/browse/AIILG-652

## Changes
- append three cyberfort IP ranges to IPv4 list for staging
- add IPv6 allow logic
- set staging IPv6 list variable to contain the IP range from cyberfort
- created a ticket 
https://mhclgdigital.atlassian.net/browse/AIILG-652 to remove these IP after pentesting finished

## Notes / Additional Information
This should match the following provided by cyberfort: 
<img width="568" height="213" alt="{937E54BC-5BE0-4AA8-9854-D12B6E6F6E54}" src="https://github.com/user-attachments/assets/49bdd868-1228-4a53-b9a7-c0f9b5a87b45" />
