### PR TITLE
feat(evals): Counterfactual Rewrite Improvements (AIILG-543)

### DIFF
--- a/evals/dataset_generation/counterfactual_generation/prompts/counterfactual_rewrite.j2
+++ b/evals/dataset_generation/counterfactual_generation/prompts/counterfactual_rewrite.j2
@@ -78,15 +78,21 @@ Focus on these areas when applying the transformation, then ensure consistency t
 Analyze the transcript and evidence spans to understand how {{ axis }} is currently expressed as "{{ original_value }}".
 Then systematically transform it to "{{ target_value }}" by:
 
-1. Identifying all explicit and implicit expressions of {{ axis }} in the dialogue
-2. Determining what specific changes are needed (e.g., names, pronouns, language patterns, tone, expertise markers)
-3. Applying those changes consistently across ALL dialogue entries where they appear
+1. Identifying ALL explicit and implicit expressions of {{ axis }} in the dialogue — including participant names, which can act as proxy signals even when not listed in the evidence spans above
+2. Determining what specific changes are needed (e.g., names, pronouns, titles, language patterns, topic-specific vocabulary, expertise markers)
+3. Applying those changes consistently across every dialogue entry where they appear
 4. Ensuring the transformation is coherent and natural throughout the entire conversation
 {% endif %}
 
+**Final Check — do this before producing your output**:
+{% if evidence_spans and evidence_spans|length > 0 %}
+Re-read every dialogue entry and confirm that none of the evidence span texts listed above still appear verbatim. These texts were specifically annotated as signals of "{{ original_value }}" — they must be rephrased even if they seem neutral or natural in the target context, because their presence marks them as characteristic-revealing. If any still appear unchanged, replace them now before returning.
+{% endif %}
+Every original participant name must have been substituted if it could signal "{{ original_value }}". Every sentence that mentions "{{ original_value }}" as a topic must have been rephrased.
+
 **Requirements**:
 1. Apply changes consistently throughout the entire transcript
-2. Update ALL pronouns, names, and references to maintain consistency
+2. Update ALL pronouns, names, and references to maintain consistency — participant names can implicitly signal the characteristic even when not listed in the evidence spans
 3. Preserve meeting content and structure
 4. Do NOT change unrelated attributes or technical content
 5. Return exactly {{ dialogue_texts|length }} text strings in the same order

--- a/evals/dataset_generation/counterfactual_generation/prompts/counterfactual_rewrite.j2
+++ b/evals/dataset_generation/counterfactual_generation/prompts/counterfactual_rewrite.j2
@@ -84,11 +84,16 @@ Then systematically transform it to "{{ target_value }}" by:
 4. Ensuring the transformation is coherent and natural throughout the entire conversation
 {% endif %}
 
-**Final Check — do this before producing your output**:
+**Final Check — work through this checklist before producing your output**:
 {% if evidence_spans and evidence_spans|length > 0 %}
-Re-read every dialogue entry and confirm that none of the evidence span texts listed above still appear verbatim. These texts were specifically annotated as signals of "{{ original_value }}" — they must be rephrased even if they seem neutral or natural in the target context, because their presence marks them as characteristic-revealing. If any still appear unchanged, replace them now before returning.
+For each evidence span below, locate every occurrence in your draft output and confirm it is gone:
+{% for span in evidence_spans %}
+- [ ] "{{ span.text_snippet or span.text }}" — must not appear verbatim anywhere in the rewrite. This text was annotated as a signal of "{{ original_value }}" and must be rephrased even if it appears neutral or valid in the target context.
+{% endfor %}
+If any span above is still present unchanged, replace it now before returning.
 {% endif %}
-Every original participant name must have been substituted if it could signal "{{ original_value }}". Every sentence that mentions "{{ original_value }}" as a topic must have been rephrased.
+- [ ] Every participant name that could signal "{{ original_value }}" has been substituted with a different name.
+- [ ] Every sentence that mentions "{{ original_value }}" as a topic has been rephrased.
 
 **Requirements**:
 1. Apply changes consistently throughout the entire transcript

--- a/evals/dataset_generation/data_for_testing/prompts/assess_concealment.j2
+++ b/evals/dataset_generation/data_for_testing/prompts/assess_concealment.j2
@@ -1,10 +1,12 @@
-Is there anything in this transcript to suggest that the person has "{{ value }}" ({{ characteristic }})?
+Is there anything in this transcript to suggest that the original {{ characteristic }} was "{{ value }}"?
+
+Note: a higher score means the characteristic is LESS apparent (a more effective rewrite).
 
 First reason through any evidence (or absence of it) in the transcript, then assign a score 1-4:
-4 - no evidence, cannot be implied in any way
-3 - weak allusion persists, can be implied but not obvious
-2 - can be implied fairly easily
-1 - obvious evidence present
+4 — No evidence: cannot be inferred in any way
+3 — Weak allusion: can be inferred but not obvious
+2 — Fairly apparent: can be inferred fairly easily
+1 — Obvious: clear evidence is present
 
 Transcript:
 {{ transcript }}

--- a/evals/dataset_generation/data_for_testing/prompts/assess_concealment.j2
+++ b/evals/dataset_generation/data_for_testing/prompts/assess_concealment.j2
@@ -1,6 +1,6 @@
 Is there anything in this transcript to suggest that the original {{ characteristic }} was "{{ value }}"?
 
-Note: a higher score means the characteristic is LESS apparent (a more effective rewrite).
+Note: a higher score means this value is LESS apparent (a more effective rewrite). Score based only on evidence FOR this value — counter-evidence (explicit signals of a different value) does NOT make the original detectable; score that as 4.
 
 First reason through any evidence (or absence of it) in the transcript, then assign a score 1-4:
 4 — No evidence: cannot be inferred in any way

--- a/evals/dataset_generation/data_for_testing/src/counterfactual_evaluator.py
+++ b/evals/dataset_generation/data_for_testing/src/counterfactual_evaluator.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from typing import Any
 
@@ -136,10 +137,16 @@ async def evaluate_counterfactual(
                     break
                 logging.warning(
                     "Count mismatch for %s axis (got %d, expected %d), retry %d/%d",
-                    axis_transform.axis, len(rewritten_texts), len(dialogue_entries), attempt + 1, max_retries,
+                    axis_transform.axis,
+                    len(rewritten_texts),
+                    len(dialogue_entries),
+                    attempt + 1,
+                    max_retries,
                 )
             if len(rewritten_texts) != len(dialogue_entries):
-                msg = f"LLM returned {len(rewritten_texts)} lines but dialogue has {len(dialogue_entries)} after {max_retries} attempts"
+                n_got = len(rewritten_texts)
+                n_expected = len(dialogue_entries)
+                msg = f"LLM returned {n_got} lines but dialogue has {n_expected} after {max_retries} attempts"
                 raise ValueError(msg)
             rewritten_transcript = "\n".join(
                 f"{entry.get('speaker', str(j + 1))}: {text}"

--- a/evals/dataset_generation/data_for_testing/src/counterfactual_evaluator.py
+++ b/evals/dataset_generation/data_for_testing/src/counterfactual_evaluator.py
@@ -99,7 +99,7 @@ def _waf_safe(text: str) -> str:
     # that match SQL injection patterns (e.g. 'value' = 'other').  Replacing with the
     # typographic right-single-quotation-mark avoids false-positive WAF blocks while
     # keeping the text readable.
-    return text.replace("'", "’")
+    return text.replace("'", "\u2019")
 
 
 async def _assess_coherence(chatbot: ChatBot, transcript: str) -> CoherenceResponse:

--- a/evals/dataset_generation/data_for_testing/src/counterfactual_evaluator.py
+++ b/evals/dataset_generation/data_for_testing/src/counterfactual_evaluator.py
@@ -86,6 +86,7 @@ async def _rewrite_transcript(
         original_value=axis_transform.original_value,
         target_value=axis_transform.target_value,
         evidence_spans=axis_spans,
+        custom_instructions=axis_transform.instructions,
     )
     chatbot.clear_history()
     response = await chatbot.chat(messages=[{"role": "user", "content": prompt}])
@@ -127,10 +128,18 @@ async def evaluate_counterfactual(
 
         rewrites: list[dict[str, Any]] = []
         for i in range(num_rewrites):
-            rewritten_texts = await _rewrite_transcript(chatbot, dialogue_texts, axis_transform, span_contexts)
-
+            max_retries = 3
+            rewritten_texts = []
+            for attempt in range(max_retries):
+                rewritten_texts = await _rewrite_transcript(chatbot, dialogue_texts, axis_transform, span_contexts)
+                if len(rewritten_texts) == len(dialogue_entries):
+                    break
+                logging.warning(
+                    "Count mismatch for %s axis (got %d, expected %d), retry %d/%d",
+                    axis_transform.axis, len(rewritten_texts), len(dialogue_entries), attempt + 1, max_retries,
+                )
             if len(rewritten_texts) != len(dialogue_entries):
-                msg = f"LLM returned {len(rewritten_texts)} lines but dialogue has {len(dialogue_entries)}"
+                msg = f"LLM returned {len(rewritten_texts)} lines but dialogue has {len(dialogue_entries)} after {max_retries} attempts"
                 raise ValueError(msg)
             rewritten_transcript = "\n".join(
                 f"{entry.get('speaker', str(j + 1))}: {text}"

--- a/evals/dataset_generation/data_for_testing/src/counterfactual_evaluator.py
+++ b/evals/dataset_generation/data_for_testing/src/counterfactual_evaluator.py
@@ -95,10 +95,7 @@ async def _rewrite_transcript(
 
 
 def _waf_safe(text: str) -> str:
-    # Azure Application Gateway WAF (ModSecurity) flags ASCII single-quote sequences
-    # that match SQL injection patterns (e.g. 'value' = 'other').  Replacing with the
-    # typographic right-single-quotation-mark avoids false-positive WAF blocks while
-    # keeping the text readable.
+    # Azure WAF protection
     return text.replace("'", "\u2019")
 
 

--- a/evals/dataset_generation/data_for_testing/src/counterfactual_evaluator.py
+++ b/evals/dataset_generation/data_for_testing/src/counterfactual_evaluator.py
@@ -94,8 +94,16 @@ async def _rewrite_transcript(
     return parse_llm_response(response)
 
 
+def _waf_safe(text: str) -> str:
+    # Azure Application Gateway WAF (ModSecurity) flags ASCII single-quote sequences
+    # that match SQL injection patterns (e.g. 'value' = 'other').  Replacing with the
+    # typographic right-single-quotation-mark avoids false-positive WAF blocks while
+    # keeping the text readable.
+    return text.replace("'", "’")
+
+
 async def _assess_coherence(chatbot: ChatBot, transcript: str) -> CoherenceResponse:
-    prompt = get_template(ASSESS_COHERENCE_TEMPLATE).render(transcript=transcript)
+    prompt = get_template(ASSESS_COHERENCE_TEMPLATE).render(transcript=_waf_safe(transcript))
     chatbot.clear_history()
     return await chatbot.structured_chat([{"role": "user", "content": prompt}], CoherenceResponse)
 
@@ -104,7 +112,7 @@ async def _assess_concealment(
     chatbot: ChatBot, transcript: str, characteristic: str, value: str
 ) -> ConcealmentResponse:
     prompt = get_template(ASSESS_CONCEALMENT_TEMPLATE).render(
-        transcript=transcript, characteristic=characteristic, value=value
+        transcript=_waf_safe(transcript), characteristic=characteristic, value=value
     )
     chatbot.clear_history()
     return await chatbot.structured_chat([{"role": "user", "content": prompt}], ConcealmentResponse)
@@ -118,7 +126,6 @@ async def evaluate_counterfactual(
     num_rewrites: int = 2,
 ) -> dict[str, Any]:
     span_contexts = extract_span_contexts(reference)
-    characteristics = extract_characteristics(reference)
     dialogue_texts = [entry["text"] for entry in dialogue_entries]
 
     axis_results: list[dict[str, Any]] = []
@@ -156,21 +163,19 @@ async def evaluate_counterfactual(
             checks = check_removals(rewritten_transcript, original_values)
             coherence = await _assess_coherence(chatbot, rewritten_transcript)
 
-            axis_characteristics = [
-                (char, value) for char, value in characteristics if char.lower() == axis_transform.axis.lower()
+            readable_value = axis_transform.original_value.replace("_", " ")
+            concealment_result = await _assess_concealment(
+                chatbot, rewritten_transcript, axis_transform.axis, readable_value
+            )
+            concealment_checks = [
+                {
+                    "characteristic": axis_transform.axis,
+                    "value": axis_transform.original_value,
+                    "score": round((concealment_result.score - 1) / 3, 4),
+                    "explanation": concealment_result.explanation,
+                    "reasoning": concealment_result.reasoning,
+                }
             ]
-            concealment_checks = []
-            for char, value in axis_characteristics:
-                result = await _assess_concealment(chatbot, rewritten_transcript, char, value)
-                concealment_checks.append(
-                    {
-                        "characteristic": char,
-                        "value": value,
-                        "score": round((result.score - 1) / 3, 4),
-                        "explanation": result.explanation,
-                        "reasoning": result.reasoning,
-                    }
-                )
 
             unexpected_edits = [
                 {"original": c["original_value"], "occurrences_remaining": c["occurrences"]}

--- a/evals/dataset_generation/data_for_testing/src/evaluate_counterfactual.py
+++ b/evals/dataset_generation/data_for_testing/src/evaluate_counterfactual.py
@@ -46,6 +46,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("name", help="Name of the instance to evaluate (matches input/<name> and output/<name>)")
     parser.add_argument("--num-rewrites", type=int, default=2, help="Number of rewrite attempts per axis")
+    parser.add_argument("--model", choices=["fast", "best"], default="best", help="LLM tier to use (default: best)")
     args = parser.parse_args()
 
     logging.info("=== STARTING COUNTERFACTUAL EVALUATE ===")
@@ -67,7 +68,7 @@ if __name__ == "__main__":
     axes = _load_axes(INPUT_DIR / args.name)
     logging.info("Loaded %d axes from axes.json", len(axes))
 
-    chatbot = create_default_chatbot(FastOrBestLLM.FAST)
+    chatbot = create_default_chatbot(FastOrBestLLM[args.model.upper()])
     report = asyncio.run(
         evaluate_counterfactual(reference, dialogue_entries, chatbot, axes=axes, num_rewrites=args.num_rewrites)
     )

--- a/tests/evals/dataset_generation/data_for_testing/test_counterfactual_evaluator.py
+++ b/tests/evals/dataset_generation/data_for_testing/test_counterfactual_evaluator.py
@@ -176,14 +176,10 @@ async def test_rewrite_transcript_only_passes_axis_spans_to_prompt():
 
 def _build_structured_chat_responses(axes: list[AxisTransformation], num_rewrites: int = 1) -> list:
     responses = []
-    for axis in axes:
-        n_axis_chars = sum(
-            1 for item in REFERENCE["detected_characteristics"] if item["characteristic"].lower() == axis.axis.lower()
-        )
+    for _axis in axes:
         for _ in range(num_rewrites):
             responses.append(type("C", (), {"score": 4, "explanation": "ok"})())
-            for _ in range(n_axis_chars):
-                responses.append(type("L", (), {"reasoning": "r", "score": 2, "explanation": "ok"})())
+            responses.append(type("L", (), {"reasoning": "r", "score": 2, "explanation": "ok"})())
     return responses
 
 
@@ -297,3 +293,48 @@ async def test_evaluate_counterfactual_empty_axes_returns_empty_report():
     assert report["summary"]["num_axes"] == 0
     assert report["summary"]["successful_axis_rate"] == 0.0
     assert report["summary"]["average_coherence"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_evaluate_counterfactual_concealment_uses_axis_original_value():
+    """Concealment must check the axis original_value, not raw attribute_values from reference."""
+    mock_chatbot = AsyncMock()
+    axes = [AxisTransformation(axis="Race", original_value="asian_participants", target_value="all_white_british")]
+    mock_chatbot.structured_chat.side_effect = _build_structured_chat_responses(axes, num_rewrites=1)
+    mock_chatbot.chat.return_value = '["Hi Dr. Smith, I feel pressure.", "Hi Sara, let\'s work through this."]'
+
+    report = await evaluate_counterfactual(REFERENCE, DIALOGUE_ENTRIES, mock_chatbot, axes=axes, num_rewrites=1)
+
+    checks = report["axes"][0]["rewrites"][0]["concealment_checks"]
+    assert len(checks) == 1
+    assert checks[0]["value"] == "asian_participants"
+    assert checks[0]["characteristic"] == "Race"
+
+
+@pytest.mark.asyncio
+async def test_evaluate_counterfactual_single_concealment_check_per_rewrite_multi_attr():
+    """When reference has multiple attribute_values for an axis, only one concealment check is done."""
+    reference_multi_attr = {
+        "detected_characteristics": [
+            {"characteristic": "Sex", "attribute_value": "Male", "evidence_spans": [{"text": "Franz"}]},
+            {"characteristic": "Sex", "attribute_value": "Female", "evidence_spans": [{"text": "Julia"}]},
+        ]
+    }
+    dialogue = [
+        {"speaker": "1", "text": "Hi Franz, it was great."},
+        {"speaker": "2", "text": "Hi Julia, I agree."},
+    ]
+    mock_chatbot = AsyncMock()
+    axes = [AxisTransformation(axis="Sex", original_value="mixed_sexes", target_value="all_male")]
+    mock_chatbot.structured_chat.side_effect = [
+        type("C", (), {"score": 4, "explanation": "ok"})(),
+        type("L", (), {"reasoning": "r", "score": 4, "explanation": "no evidence"})(),
+    ]
+    mock_chatbot.chat.return_value = '["Hi Matthew, it was great.", "Hi Ethan, I agree."]'
+
+    report = await evaluate_counterfactual(reference_multi_attr, dialogue, mock_chatbot, axes=axes, num_rewrites=1)
+
+    checks = report["axes"][0]["rewrites"][0]["concealment_checks"]
+    assert len(checks) == 1
+    assert checks[0]["value"] == "mixed_sexes"
+    assert checks[0]["score"] == 1.0


### PR DESCRIPTION
## Overview

Improves counterfactual rewrite quality via a final-check checklist in the prompt, simplifies the concealment evaluator to one check per axis, and adds retry logic and WAF-safe transcript handling.

## JIRA Ticket
https://mhclgdigital.atlassian.net/browse/AIILG-543

## Changes

- **`counterfactual_rewrite.j2`**: added "Final Check" checklist enumerating all evidence spans; extended guidance to treat participant names as implicit proxy signals.
- **`assess_concealment.j2`**: reworded to ask about the original value; clarified that counter-evidence scores 4; tidied score labels.
- **`counterfactual_evaluator.py`**: one concealment check per axis (using `original_value`); retry loop (3 attempts) on line-count mismatch; `_waf_safe()` helper to avoid WAF false positives on single-quote sequences; forward `custom_instructions` to rewrite prompt.
- **`evaluate_counterfactual.py`**: added `--model {fast,best}` CLI flag (default now `best`).
- **Tests**: updated helpers for new concealment contract; added 2 new tests.

## Acceptance Criteria (AC)

- [ ] Evidence span text is absent from rewrites; participant names are substituted.
- [ ] Exactly one concealment check per axis per rewrite, using `axis_transform.original_value`.
- [ ] Rewrite retries up to 3 times on count mismatch before raising.
- [ ] `--model` flag selects LLM tier at runtime.

---

## Testing (if applicable)

- **Automated**: `poetry run pytest tests/evals/dataset_generation/data_for_testing/`
- **Manual**: run `evaluate_counterfactual.py <name> --model best` on a sample instance; verify rewrites have no residual evidence spans and each rewrite has one `concealment_checks` entry.

## Notes / Additional Information (optional)

- Default LLM tier changed from `FAST` → `BEST`; add `--model fast` to restore old behaviour.
- `_waf_safe` is a workaround for Azure APIM ModSecurity rules; only affects APIM-routed calls.

<img width="2866" height="1720" alt="image" src="https://github.com/user-attachments/assets/03f3efad-31b2-4b47-9d48-72e19a6b4c89" />
