### PR TITLE
chore: disable internal access on staging so pentesters can access

### DIFF
--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -78,7 +78,7 @@ module "frontdoor" {
   cloudwatch_log_expiration_days = local.cloudwatch_log_expiration_days
 
   use_aws_shield_advanced = false
-  enable_oidc_auth        = true
+  enable_oidc_auth        = false # TODO AIILG-653 reenable after pen testing is complete
   ip_allowlist = [
     # Softwire
     "31.221.86.178/32",
@@ -203,7 +203,7 @@ module "ecs" {
   lb_security_group_id = module.frontdoor.load_balancer.security_group_id
   db_security_group_id = module.database.rds_security_group_id
   bastion_sg_id        = module.bastion.security_group_id
-  environment          = "staging"
+  environment          = "local" # TODO AIILG-653 revert to "staging" after pen testing is complete
   data_s3_bucket_name  = module.uploads_bucket.bucket_name
   private_subnet_ids   = module.networking.private_subnets[*].id
   vpc_id               = module.networking.vpc.id


### PR DESCRIPTION
# Overview
Disable internal access on staging so we'll all use one user account again. This is so that our pentester can access the site to conduct testing while his communities email is still pending.

## JIRA Ticket
https://mhclgdigital.atlassian.net/browse/AIILG-652