### PR TITLE
fix: remove module-level depends_on to prevent S3 log bucket replacement

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -95,7 +95,6 @@ module "frontdoor" {
   internal_access_oidc_client_id_name     = module.secrets.internal_access_oidc_client_id_name
   internal_access_oidc_client_secret_name = module.secrets.internal_access_oidc_client_secret_name
 
-  depends_on = [module.secrets]
 }
 
 module "certificates" {

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -104,7 +104,6 @@ module "frontdoor" {
   internal_access_oidc_client_id_name     = module.secrets.internal_access_oidc_client_id_name
   internal_access_oidc_client_secret_name = module.secrets.internal_access_oidc_client_secret_name
 
-  depends_on = [module.secrets]
 }
 
 module "certificates" {


### PR DESCRIPTION
This PR removes the module-level `depends_on` from the frontdoor modules in both the development and staging environments. This resolves a Terraform planning issue where the CloudFront S3 log bucket was being unexpectedly forced into a destroy-and-recreate replacement cycle due to deferred data source evaluation.

This issue was exposed after adding the new Sentry secrets. Because module.secrets had pending changes, the broad module-level depends_on in frontdoor forced Terraform to defer all internal data sources (specifically the AWS Account ID check), which turned the S3 bucket name into a (known after apply) value. Removing the depends_on establishes cleaner implicit resource-level dependencies.t

Because this module level depends is removed, and the secrets are genuinely a dependency of the "frontdoor" module. This might cause a deployment issue when standing up an environment for the first time. Is should be mitigated by the initial `ssl_certs_created=false` deployment as that will create the secrets before they're read on the later `ssl_certs_created=true` deployment. If that fails to fix it, we can implement an explicit `secrets_created/secrets_populated` variable which gates this further. 

