### PR TITLE
bug(frontend): Conflict with dev script's target (AIILG-685)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "setup:govuk": "cpy \"node_modules/govuk-frontend/dist/govuk/assets/**/*\" public/assets/govuk",
     "prebuild": "npm run setup:govuk",
     "predev": "npm run setup:govuk",
-    "dev": "dotenv -e ../.env.local -- next dev --webpack",
+    "dev": "dotenv -e ../.env -- next dev --webpack",
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",


### PR DESCRIPTION
# Overview
The dev script made reference to env.local which no longer exists. This caused the local development environment to fail on startup due to unresolved settings. 

## JIRA Ticket
https://mhclgdigital.atlassian.net/browse/AIILG-685

## Changes
- changed script's target from env.local to the root's env file 


