### PR TITLE
fix(infra): Invalid alb access logs perms (AIILG-698)

### DIFF
--- a/terraform/modules/frontdoor/load_balancer.tf
+++ b/terraform/modules/frontdoor/load_balancer.tf
@@ -28,8 +28,8 @@ resource "aws_lb" "main" {
 module "alb_logs" {
   source = "../s3_bucket"
 
-  bucket_name                        = "alb-logs-${var.environment_name}-${data.aws_caller_identity.current.account_id}"
-  access_log_bucket_name             = "alb-logs-${var.environment_name}-access-logs-${data.aws_caller_identity.current.account_id}"
+  bucket_name                        = "local-transcribe-alb-logs-${var.environment_name}"
+  access_log_bucket_name             = "local-transcribe-alb-logs-access-logs-${var.environment_name}"
   force_destroy                      = false
   object_lock_enabled                = false
   noncurrent_version_expiration_days = 700

--- a/terraform/modules/frontdoor/load_balancer.tf
+++ b/terraform/modules/frontdoor/load_balancer.tf
@@ -61,12 +61,26 @@ data "aws_iam_policy_document" "alb_logs_bucket_policy" {
       identifiers = ["logdelivery.elasticloadbalancing.amazonaws.com"]
     }
 
-    actions = ["s3:PutObject"]
-    resources = [
-      "${module.alb_logs.bucket_arn}/alb/AWSLogs/${data.aws_caller_identity.current.account_id}/*"
-    ]
+    actions   = ["s3:PutObject"]
+    resources = ["${module.alb_logs.bucket_arn}/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceArn"
+      values   = [aws_lb.main.arn]
+    }
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values = [
+        "arn:aws:elasticloadbalancing:eu-west-2:${data.aws_caller_identity.current.account_id}:loadbalancer/*",
+      ]
+
+    }
 
   }
+
 }
 
 

--- a/terraform/modules/frontdoor/load_balancer.tf
+++ b/terraform/modules/frontdoor/load_balancer.tf
@@ -61,15 +61,11 @@ data "aws_iam_policy_document" "alb_logs_bucket_policy" {
       identifiers = ["logdelivery.elasticloadbalancing.amazonaws.com"]
     }
 
-    actions   = ["s3:PutObject"]
-    resources = ["${module.alb_logs.bucket_arn}/*"]
+    actions = ["s3:PutObject"]
+    resources = [
+      "${module.alb_logs.bucket_arn}/alb/AWSLogs/${data.aws_caller_identity.current.account_id}/*"
+    ]
 
-
-    condition {
-      test     = "StringEquals"
-      variable = "aws:SourceArn"
-      values   = [aws_lb.main.arn]
-    }
   }
 }
 

--- a/terraform/modules/frontdoor/load_balancer.tf
+++ b/terraform/modules/frontdoor/load_balancer.tf
@@ -28,8 +28,8 @@ resource "aws_lb" "main" {
 module "alb_logs" {
   source = "../s3_bucket"
 
-  bucket_name                        = "alb-logs-${var.environment_name}"
-  access_log_bucket_name             = "alb-logs-${var.environment_name}-access-logs"
+  bucket_name                        = "alb-logs-${var.environment_name}-${data.aws_caller_identity.current.account_id}"
+  access_log_bucket_name             = "alb-logs-${var.environment_name}-access-logs-${data.aws_caller_identity.current.account_id}"
   force_destroy                      = false
   object_lock_enabled                = false
   noncurrent_version_expiration_days = 700

--- a/terraform/modules/frontdoor/load_balancer.tf
+++ b/terraform/modules/frontdoor/load_balancer.tf
@@ -28,8 +28,8 @@ resource "aws_lb" "main" {
 module "alb_logs" {
   source = "../s3_bucket"
 
-  bucket_name                        = "local-transcribe-alb-logs-${var.environment_name}"
-  access_log_bucket_name             = "local-transcribe-alb-logs-access-logs-${var.environment_name}"
+  bucket_name                        = "alb-logs-${var.environment_name}-${data.aws_caller_identity.current.account_id}"
+  access_log_bucket_name             = "alb-logs-${var.environment_name}-access-logs-${data.aws_caller_identity.current.account_id}"
   force_destroy                      = false
   object_lock_enabled                = false
   noncurrent_version_expiration_days = 700


### PR DESCRIPTION
# Overview

`"Access Denied for bucket: local-transcribe-alb-logs-development. Please check S3 bucket permission"`

<img width="1075" height="196" alt="Screenshot 2026-06-23 at 11 17 05" src="https://github.com/user-attachments/assets/69e68368-25e6-4811-8414-ea0e8392a368" />

## JIRA Ticket
https://mhclgdigital.atlassian.net/browse/AIILG-698

## Changes

- Amended policy to be consistent aws documentation. Removed sourceArn condition and matched the resource naming convention (their use of the prefix is explicit, _might be_ the catalyst...)

